### PR TITLE
Support instance or class in decorator

### DIFF
--- a/tartiflette/directive/directive.py
+++ b/tartiflette/directive/directive.py
@@ -1,3 +1,5 @@
+from inspect import isclass
+
 from tartiflette.schema.registry import SchemaRegistry
 from tartiflette.types.exceptions.tartiflette import (
     MissingImplementation,
@@ -46,8 +48,9 @@ class Directive:
             )
 
     def __call__(self, implementation):
-        self._implementation = implementation
-
+        if isclass(implementation):
+            self._implementation = implementation()
+        else:
+            self._implementation = implementation
         SchemaRegistry.register_directive(self._schema_name, self)
-
         return implementation

--- a/tartiflette/engine.py
+++ b/tartiflette/engine.py
@@ -48,7 +48,9 @@ async def _import_builtins(imported_modules, sdl, schema_name):
     for module in _BUILTINS_MODULES:
         try:
             module = import_module(module)
-            sdl = f"{sdl}\n{await _bake_module(module, schema_name)}"
+            sdl = "{sdl}\n{msdl}".format(
+                sdl=sdl, msdl=await _bake_module(module, schema_name)
+            )
             imported_modules.append(module)
         except ImproperlyConfigured:
             pass
@@ -70,7 +72,10 @@ async def _import_modules(modules, schema_name):
         module = import_module(module["name"])
 
         if callable(getattr(module, "bake", None)):
-            sdl = f"{sdl}\n{await _bake_module(module, schema_name, config) or ''}"
+            sdl = "{sdl}\n{msdl}".format(
+                sdl=sdl,
+                msdl=await _bake_module(module, schema_name, config) or "",
+            )
 
         imported_modules.append(module)
 

--- a/tartiflette/scalar/custom_scalar.py
+++ b/tartiflette/scalar/custom_scalar.py
@@ -1,3 +1,5 @@
+from inspect import isclass
+
 from tartiflette.schema.registry import SchemaRegistry
 from tartiflette.types.exceptions.tartiflette import (
     MissingImplementation,
@@ -51,6 +53,9 @@ class Scalar:
         scalar.coerce_input = self._implementation.coerce_input
 
     def __call__(self, implementation):
-        self._implementation = implementation
+        if isclass(implementation):
+            self._implementation = implementation()
+        else:
+            self._implementation = implementation
         SchemaRegistry.register_scalar(self._schema_name, self)
         return implementation

--- a/tests/unit/directives/test_directive.py
+++ b/tests/unit/directives/test_directive.py
@@ -67,4 +67,4 @@ def test_directive_bake(clean_registry):
     a_directive(dontcare)
 
     assert a_directive.bake(schema) is None
-    assert directive_internal.implementation == dontcare
+    assert isinstance(directive_internal.implementation, dontcare)


### PR DESCRIPTION
Fix a compatibility issue with the new Plugin API.
Now Directive/Scalar decorators supports instance or classes.
