### PR TITLE
ISSUE-270: Consider Int var Values as valid Float

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Released]
 
 - [0.12.x]
+  - [0.12.4](./changelogs/0.12.4.md) - 2019-08-08
   - [0.12.3](./changelogs/0.12.3.md) - 2019-07-23
   - [0.12.2](./changelogs/0.12.2.md) - 2019-07-18
   - [0.12.1](./changelogs/0.12.1.md) - 2019-07-17

--- a/changelogs/0.12.4.md
+++ b/changelogs/0.12.4.md
@@ -1,0 +1,5 @@
+# [0.12.4] - 2019-08-08
+
+## Fixed
+
+- [ISSUE-270](https://github.com/dailymotion/tartiflette/issues/270) - Some Float var where mistaken as Int

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _TEST_REQUIRE = [
 
 _BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
-_VERSION = "0.12.3"
+_VERSION = "0.12.4"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 

--- a/tartiflette/parser/visitor/visitor.py
+++ b/tartiflette/parser/visitor/visitor.py
@@ -481,7 +481,10 @@ class TartifletteVisitor(Visitor):
             )
 
         try:
-            if not isinstance(a_value, a_type):
+            # pylint: disable=unidiomatic-typecheck
+            if not (
+                a_type == float and type(a_value) == int
+            ) and not isinstance(a_value, a_type):
                 self._add_exception(
                     InvalidType(
                         "Given value for < %s > is not type < %s >"

--- a/tests/functional/regressions/test_issue270.py
+++ b/tests/functional/regressions/test_issue270.py
@@ -1,0 +1,70 @@
+import json
+
+import pytest
+
+from tartiflette import Resolver, create_engine
+
+
+@pytest.fixture(scope="module")
+async def ttftt_engine():
+    @Resolver("Mutation.mutateFloat", schema_name="issue270")
+    async def resolver_test(pr, args, ctx, info, **kwargs):
+        return {"bingo": f"{args['aFloat']}"}
+
+    return await create_engine(
+        sdl="""
+
+        type Payload {
+            clientMutationId: String,
+            bingo: String
+        }
+
+        type Mutation {
+            mutateFloat(aFloat: Float): Payload
+        }
+
+        type Query {
+            bob: String
+        }
+        """,
+        schema_name="issue270",
+    )
+
+
+@pytest.mark.parametrize(
+    "query, variables, expected",
+    [
+        (
+            "mutation($var: Float!) { mutateFloat(aFloat: $var){ bingo } } ",
+            {"var": 5},
+            {"data": {"mutateFloat": {"bingo": "5.0"}}},
+        ),
+        (
+            "mutation($var: Float!) { mutateFloat(aFloat: $var){ bingo } } ",
+            {"var": 5.0},
+            {"data": {"mutateFloat": {"bingo": "5.0"}}},
+        ),
+        (
+            "mutation($var: Float!) { mutateFloat(aFloat: $var){ bingo } } ",
+            {"var": 5.1},
+            {"data": {"mutateFloat": {"bingo": "5.1"}}},
+        ),
+        (
+            "mutation($var: Float!) { mutateFloat(aFloat: $var){ bingo } } ",
+            {"var": True},
+            {
+                "data": None,
+                "errors": [
+                    {
+                        "locations": [{"column": 10, "line": 1}],
+                        "message": "Given value for < var > is not type < <class 'float'> >",
+                        "path": None,
+                    }
+                ],
+            },
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_issue270(query, variables, expected, ttftt_engine):
+    assert await ttftt_engine.execute(query, variables=variables) == expected


### PR DESCRIPTION
fix #270 

I use `# pylint: disable=unidiomatic-typecheck` and `type` because of :

```
Python 3.7.3 (default, Apr  3 2019, 05:39:12) 
[GCC 8.3.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> a = True
>>> isinstance(a, int)
True
>>> 
```

Only `int` should be allowed as Float.

All this is wiil be done correctly in 1.x.x (which is near to being ready soon)

