### PR TITLE
Update libgraphqlparser to latest master

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,19 @@
 
 **Tartiflette** is a GraphQL Server implementation built with **Python 3.6+**.
 
+**Summary**
+
+- [Motivation](#motivation)
+- [Status](#status)
+- [Usage](#usage)
+- [Installation](#installation)
+  - [Installation dependencies](#installation-dependencies)
+- [Tartiflette over HTTP](#tartiflette-over-http)
+- [Roadmaps](#roadmaps)
+- [How to contribute to the documentation?](#how-to-contribute-to-the-documentation)
+  - [How to run the website locally?](#how-to-run-the-website-locally)
+- [Known issues](#known-issues)
+
 ## Motivation
 
 [Read this blogpost about our motivations](https://medium.com/dailymotion/tartiflette-graphql-api-engine-python-open-source-a200c5bbc477)
@@ -23,19 +36,6 @@ We reached the limits of Graphene, we wanted to build something which met certai
 * **Simple is better than complex:** Built with [the Zen of Python](https://www.python.org/dev/peps/pep-0020/#id3) in mind. No over-engineering.
 
 Discover Tartiflette with our fabulous tutorial on [https://tartiflette.io/docs/tutorial/getting-started](https://tartiflette.io/docs/tutorial/getting-started)
-
-**Summary**
-
-- [Motivation](#motivation)
-- [Status](#status)
-- [Usage](#usage)
-- [Installation](#installation)
-  - [Installation dependencies](#installation-dependencies)
-- [Tartiflette over HTTP](#tartiflette-over-http)
-- [Roadmaps](#roadmaps)
-- [How to contribute to the documentation?](#how-to-contribute-to-the-documentation)
-  - [How to run the website locally?](#how-to-run-the-website-locally)
-- [Known issues](#known-issues)
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -26,11 +26,15 @@ Discover Tartiflette with our fabulous tutorial on [https://tartiflette.io/docs/
 
 **Summary**
 
+- [Motivation](#motivation)
+- [Status](#status)
 - [Usage](#usage)
 - [Installation](#installation)
   - [Installation dependencies](#installation-dependencies)
 - [Tartiflette over HTTP](#tartiflette-over-http)
 - [Roadmaps](#roadmaps)
+- [How to contribute to the documentation?](#how-to-contribute-to-the-documentation)
+  - [How to run the website locally?](#how-to-run-the-website-locally)
 - [Known issues](#known-issues)
 
 ## Usage
@@ -89,6 +93,8 @@ brew install cmake flex bison
 ```bash
 apt-get install cmake flex bison
 ```
+
+Make sure you have `bison` in verions 3
 
 ## Tartiflette over HTTP
 

--- a/changelogs/1.0.0.md
+++ b/changelogs/1.0.0.md
@@ -10,6 +10,8 @@
 
 ## Changed
 
+- Bump the `libgraphqlparser` submodule to latest master commits so we can now support triple quoted strings as litteral values for parameters.
+  **Note**: It's important to have at least `bison` in version >= 3 on your system before installing tartiflette.
 - Bump the `lark-parser` package to version `0.7.3`
 - [ISSUE-121](https://github.com/dailymotion/tartiflette/issues/121) - The grammar used by the lark parser used in the SDL parsing has been updated to conform to the [June 2018 GraphQL specification](https://graphql.github.io/graphql-spec/June2018/)
 - [ISSUE-121](https://github.com/dailymotion/tartiflette/issues/121) - Both SDL and query parsing does now focus only on the parsing part and returns an instance of `DocumentNode` that can be treated generically

--- a/tests/functional/coercers/test_coercer_string_field.py
+++ b/tests/functional/coercers/test_coercer_string_field.py
@@ -21,7 +21,7 @@ from tests.functional.coercers.common import resolve_unwrapped_field
             {"data": {"stringField": "SUCCESS-None"}},
         ),
         (
-            """query { stringField(param: "paramDefaultValue) }""",
+            """query { stringField(param: "paramDefaultValue") }""",
             None,
             {
                 "data": {

--- a/tests/functional/coercers/test_coercer_string_field.py
+++ b/tests/functional/coercers/test_coercer_string_field.py
@@ -21,7 +21,7 @@ from tests.functional.coercers.common import resolve_unwrapped_field
             {"data": {"stringField": "SUCCESS-None"}},
         ),
         (
-            """query { stringField(param: "paramDefaultValue") }""",
+            """query { stringField(param: "paramDefaultValue) }""",
             None,
             {
                 "data": {

--- a/tests/functional/regressions/test_multiline_strings.py
+++ b/tests/functional/regressions/test_multiline_strings.py
@@ -1,0 +1,54 @@
+import pytest
+
+from tartiflette import Resolver, create_engine
+
+
+@pytest.fixture(scope="module", name="ttftt_engine")
+async def ttftt_engine_fixture():
+    sdl = """
+type Query {
+    simpleParameterField(s: String): String
+}
+"""
+
+    @Resolver(
+        "Query.simpleParameterField",
+        schema_name="test_regressions_multiline_strings",
+    )
+    async def resolver(_pr, args, _ctx, _info):
+        return str(args)
+
+    return await create_engine(
+        sdl, schema_name="test_regressions_multiline_strings"
+    )
+
+
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        (
+            """
+            query {
+                simpleParameterField(s:\"\"\"a\"\"\")
+            }
+            """,
+            {"data": {"simpleParameterField": "{'s': 'a'}"}},
+        ),
+        (
+            """
+            query {
+                simpleParameterField(s:\"\"\"a
+
+
+                b\"\"\")
+            }
+            """,
+            {"data": {"simpleParameterField": "{'s': 'a\\n\\n\\nb'}"}},
+        ),
+    ],
+)
+@pytest.mark.asyncio
+async def test_validators_all_variable_usages_are_allowed(
+    query, expected, ttftt_engine
+):
+    assert await ttftt_engine.execute(query) == expected


### PR DESCRIPTION
Cause we want the support of multiline string ("""example""") as litteral input value.