### PR TITLE
Upgrade Libgraphqlparser to python3 only version

### DIFF
--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -5,22 +5,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: build docker image
-        uses: actions/docker/cli@master
-        with:
-          args: build -t tartiflette .
       - name: style
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make style
+          args: make style
       - name: functional test
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make test-functional
+          args: make test-functional
       - name: unit test
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make test-unit
+          args: make test-unit
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -8,22 +8,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@master
-      - name: build docker image
-        uses: actions/docker/cli@master
-        with:
-          args: build -t tartiflette .
       - name: style
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make style
+          args: make style
       - name: functional test
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make test-functional
+          args: make test-functional
       - name: unit test
-        uses: actions/docker/cli@master
+        uses: ./
         with:
-          args: run -i tartiflette make test-unit
+          args: make test-unit
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master
         env:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 - [1.x.x]
   - [1.1.x]
-    - [1.1.0](./changelogs/1.1.0.md) - 2019-10-03
     - [1.1.1](./changelogs/1.1.1.md) - 2019-10-10
+    - [1.1.0](./changelogs/1.1.0.md) - 2019-10-03
   - [1.0.x]
     - [1.0.0](./changelogs/1.0.0.md) - 2019-09-20
 - [0.x.x]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 ## [Released]
 
 - [1.x.x]
+  - [1.1.x]
+    - [1.1.0](./changelogs/1.1.0.md) - 2019-10-03
+    - [1.1.1](./changelogs/1.1.1.md) - 2019-10-10
   - [1.0.x]
     - [1.0.0](./changelogs/1.0.0.md) - 2019-09-20
 - [0.x.x]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7.2
+FROM python:3.7.4
 
 RUN apt-get update && apt-get install -y cmake bison flex git jq
 

--- a/changelogs/1.1.1.md
+++ b/changelogs/1.1.1.md
@@ -1,0 +1,17 @@
+# [1.1.1] - 2019-10-10
+
+## Changed
+
+Update some Test Framework dependencies:
+  - Update pytest to 5.2.1
+  - Update pytest-xdist to 1.30.0
+  - Update pytest-co to 2.81
+
+Update dependencies:
+  - Update lark-parser to 0.7.7
+
+Update libgraphqlparser to HEAD of abu/remove_python2 branch.
+
+## Fixed
+
+- [ISSUE-301](https://github.com/tartiflette/tartiflette/issues/301) - CtypeGen should not bother you anymore.

--- a/changelogs/next.md
+++ b/changelogs/next.md
@@ -4,12 +4,4 @@
 
 ## Changed
 
-Update some Test Framework dependencies:
-  - Update pytest to 5.2.1
-  - Update pytest-xdist to 1.30.0
-  - Update pytest-co to 2.81
-
-Update dependencies:
-  - Update lark-parser to 0.7.7
-
 ## Fixed

--- a/setup.py
+++ b/setup.py
@@ -60,7 +60,7 @@ _TEST_REQUIRE = [
 
 _BENCHMARK_REQUIRE = ["pytest-benchmark==3.2.2"]
 
-_VERSION = "1.1.0"
+_VERSION = "1.1.1"
 
 _PACKAGES = find_packages(exclude=["tests*"])
 


### PR DESCRIPTION
closes #301 

With this PR, ctypegen is no more needed for us.
Only python 3 is required to generated the .h files (but this is useless for us too, I'm thinking about removing it too). 
If I have more time later I'll do an "optionnable" thing so it'll be more easily mainlined.

@florimondmanca I'll ping you with a `test.pypi.org/simple` lib when it'll be ready so you could test it.