### PR TITLE
ISSUE-381, find a way to call post_out on type when they are accessed via a Union.

### DIFF
--- a/tartiflette/coercers/outputs/abstract_coercer.py
+++ b/tartiflette/coercers/outputs/abstract_coercer.py
@@ -97,20 +97,19 @@ async def abstract_coercer(
         execution_context.schema.default_type_resolver,
     )
 
-    return await complete_object_value(
-        result,
-        info,
+    runtime_type = ensure_valid_runtime_type(
+        type_resolver(result, execution_context.context, info, abstract_type),
         execution_context,
+        abstract_type,
         field_nodes,
-        path,
-        ensure_valid_runtime_type(
-            type_resolver(
-                result, execution_context.context, info, abstract_type
-            ),
-            execution_context,
-            abstract_type,
-            field_nodes,
-            info,
-            result,
-        ),
+        info,
+        result,
+    )
+
+    result = await complete_object_value(
+        result, info, execution_context, field_nodes, path, runtime_type
+    )
+
+    return await runtime_type.output_coercer(
+        result, info, execution_context, field_nodes, path
     )

--- a/tartiflette/coercers/outputs/abstract_coercer.py
+++ b/tartiflette/coercers/outputs/abstract_coercer.py
@@ -106,10 +106,16 @@ async def abstract_coercer(
         result,
     )
 
-    result = await complete_object_value(
-        result, info, execution_context, field_nodes, path, runtime_type
-    )
-
-    return await runtime_type.output_coercer(
-        result, info, execution_context, field_nodes, path
+    return await complete_object_value(
+        await runtime_type.pre_output_coercion_directives(
+            result,
+            execution_context.context,
+            info,
+            context_coercer=execution_context.context,
+        ),
+        info,
+        execution_context,
+        field_nodes,
+        path,
+        runtime_type,
     )

--- a/tartiflette/types/object.py
+++ b/tartiflette/types/object.py
@@ -157,11 +157,7 @@ class GraphQLObjectType(GraphQLCompositeType, GraphQLType):
         self.output_coercer = partial(
             output_directives_coercer,
             coercer=partial(object_coercer, object_type=self),
-            directives=wraps_with_directives(
-                directives_definition=directives_definition,
-                directive_hook="on_pre_output_coercion",
-                with_default=True,
-            ),
+            directives=self.pre_output_coercion_directives,
         )
 
     async def bake_fields(

--- a/tartiflette/types/object.py
+++ b/tartiflette/types/object.py
@@ -54,6 +54,7 @@ class GraphQLObjectType(GraphQLCompositeType, GraphQLType):
         # Directives
         self.directives = directives
         self.introspection_directives: Optional[Callable] = None
+        self.pre_output_coercion_directives: Optional[Callable] = None
 
         # Coercers
         self.output_coercer: Optional[Callable] = None
@@ -144,6 +145,12 @@ class GraphQLObjectType(GraphQLCompositeType, GraphQLType):
         self.introspection_directives = wraps_with_directives(
             directives_definition=directives_definition,
             directive_hook="on_introspection",
+        )
+
+        self.pre_output_coercion_directives = wraps_with_directives(
+            directives_definition=directives_definition,
+            directive_hook="on_pre_output_coercion",
+            with_default=True,
         )
 
         # Coercers

--- a/tartiflette/types/union.py
+++ b/tartiflette/types/union.py
@@ -57,7 +57,7 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
         self.introspection_directives: Optional[Callable] = None
 
         # Coercers
-        self._output_coercer: Optional[Callable] = None
+        self.output_coercer: Optional[Callable] = None
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/union.py
+++ b/tartiflette/types/union.py
@@ -51,13 +51,14 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
         self._possible_types: List["GraphQLType"] = []
         self._possible_types_set: Set[str] = set()
         self._fields: Dict[str, "GraphQLField"] = {}
+        self._possible_types_dict: Dict[str, GraphQLType] = {}
 
         # Directives
         self.directives = directives
         self.introspection_directives: Optional[Callable] = None
 
         # Coercers
-        self.output_coercer: Optional[Callable] = None
+        self._output_coercer: Optional[Callable] = None
 
     def __eq__(self, other: Any) -> bool:
         """
@@ -153,6 +154,7 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
             schema_type = schema.find_type(type_name)
             self._possible_types.append(schema_type)
             self._possible_types_set.add(type_name)
+            self._possible_types_dict[type_name] = schema_type
 
         # Directives
         directives_definition = compute_directive_nodes(
@@ -164,7 +166,7 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
         )
 
         # Coercers
-        self.output_coercer = partial(
+        self._output_coercer = partial(
             output_directives_coercer,
             coercer=partial(abstract_coercer, abstract_type=self),
             directives=wraps_with_directives(
@@ -172,6 +174,35 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
                 directive_hook="on_pre_output_coercion",
                 with_default=True,
             ),
+        )
+
+    async def output_coercer(
+        self,
+        result: Any,
+        info: "ResolveInfo",
+        execution_context: "ExecutionContext",
+        field_nodes: List["FieldNode"],
+        path: "Path",
+    ):
+
+        type_resolver = self.get_type_resolver(
+            f"{info.parent_type.name}.{info.field_name}",
+            execution_context.schema.default_type_resolver,
+        )
+
+        result_type = type_resolver(
+            result, execution_context.context, info, self
+        )
+
+        if result_type in self._possible_types_set:
+            result = await self._possible_types_dict[
+                result_type
+            ].output_coercer(
+                result, info, execution_context, field_nodes, path
+            )
+
+        return await self._output_coercer(
+            result, info, execution_context, field_nodes, path
         )
 
     async def bake_fields(

--- a/tests/functional/regressions/test_issue381.py
+++ b/tests/functional/regressions/test_issue381.py
@@ -2,67 +2,130 @@ import pytest
 
 from tartiflette import Directive, Resolver, TypeResolver, create_engine
 
-_SDL = """ schema {
-  query: Query
-}
 
-directive @run_me_this on OBJECT
+@pytest.fixture(scope="module")
+async def ttftt_engine_union():
+    schema_name = "test_issue381"
 
-type Query {
-  rootQueryField(resp: Int): CoupleOfResponses
-}
+    sdl = """ schema {
+        query: Query
+    }
 
-union CoupleOfResponses = ResponseOne | ResponseTwo
+    directive @run_me_this_object on OBJECT
+    directive @run_me_this_ifa on INTERFACE
+    directive @run_me_this_union on UNION
 
-type ResponseOne @run_me_this {
-    a: String
-}
+    type Query {
+        aFieldUnionObj: CoupleOfResponses
+        aFieldObj: CoupleOfResponsesNoUnionDir
+        aFieldIfa: AnIfa
+    }
 
+    union CoupleOfResponses @run_me_this_union = ResponseOne | ResponseTwo
+    union CoupleOfResponsesNoUnionDir = ResponseOne | ResponseTwo
 
-type ResponseTwo {
-   b: Int
-}
-"""
+    interface AnIfa @run_me_this_ifa {
+        a: String
+    }
 
+    type ResponseOne @run_me_this_object {
+        a: String
+    }
 
-@Directive(name="run_me_this", schema_name="test_issue381")
-class RunMeThis:
-    async def on_pre_output_coercion(
-        self, directive_args, next_directive, value, ctx, info
-    ):
-        bob = await next_directive(value, ctx, info)
-        return {"a": f"{bob['a']} 2"}
+    type ResponseThree implements AnIfa {
+        a: String
+    }
 
+    type ResponseTwo {
+        b: Int
+    }
+    """
 
-@Resolver("Query.rootQueryField", schema_name="test_issue381")
-async def resolve_root_query_field(pr, args, ctx, info):
-    return {"a": "LOOOL "}
+    @Directive(name="run_me_this_object", schema_name=schema_name)
+    class RunMeThisObject:
+        async def on_pre_output_coercion(
+            self, directive_args, next_directive, value, ctx, info
+        ):
+            bob = await next_directive(value, ctx, info)
+            return {"a": f"{bob['a']} obj"}
 
+    @Directive(name="run_me_this_union", schema_name=schema_name)
+    class RunMeThisUnion:
+        async def on_pre_output_coercion(
+            self, directive_args, next_directive, value, ctx, info
+        ):
+            bob = await next_directive(value, ctx, info)
+            return {"a": f"{bob['a']} union"}
 
-@TypeResolver("CoupleOfResponses", schema_name="test_issue381")
-def resolve_type_couple_of_responses(result, context, info, abstract_type):
-    if "a" in result:
-        return "ResponseOne"
-    return "ResponseTwo"
+    @Directive(name="run_me_this_ifa", schema_name=schema_name)
+    class RunMeThisIfa:
+        async def on_pre_output_coercion(
+            self, directive_args, next_directive, value, ctx, info
+        ):
+            bob = await next_directive(value, ctx, info)
+            return {"a": f"{bob['a']} ifa"}
+
+    @Resolver("Query.aFieldUnionObj", schema_name=schema_name)
+    @Resolver("Query.aFieldObj", schema_name=schema_name)
+    @Resolver("Query.aFieldIfa", schema_name=schema_name)
+    async def resolve_root_query_field(pr, args, ctx, info):
+        return {"a": "LOOOL"}
+
+    @TypeResolver("CoupleOfResponses", schema_name=schema_name)
+    @TypeResolver("CoupleOfResponsesNoUnionDir", schema_name=schema_name)
+    def resolve_type_couple_of_responses(result, context, info, abstract_type):
+        if "a" in result:
+            return "ResponseOne"
+        return "ResponseTwo"
+
+    @TypeResolver("AnIfa", schema_name=schema_name)
+    def resolve_type_ifa(result, context, info, abstract_type):
+        return "ResponseThree"
+
+    return await create_engine(sdl=sdl, schema_name=schema_name)
 
 
 @pytest.mark.asyncio
-async def test_issue381_output_coercion_on_union():
-    e = await create_engine(sdl=_SDL, schema_name="test_issue381")
-    assert (
-        await e.execute(
+@pytest.mark.parametrize(
+    "query,expected",
+    [
+        (
             """
 query {
-    rootQueryField(resp: 1) {
+    aFieldUnionObj {
         ...on ResponseOne {
             a
         }
-        ...on ResponseTwo {
-            b
+    }
+}
+""",
+            {"data": {"aFieldUnionObj": {"a": "LOOOL union obj"}}},
+        ),
+        (
+            """
+query {
+    aFieldObj {
+        ...on ResponseOne {
+            a
         }
     }
 }
-"""
-        )
-        == {"data": {"rootQueryField": {"a": "LOOOL  2"}}}
-    )
+            """,
+            {"data": {"aFieldObj": {"a": "LOOOL obj"}}},
+        ),
+        (
+            """
+query {
+    aFieldIfa {
+        ...on ResponseThree { a }
+    }
+}
+            """,
+            {"data": {"aFieldIfa": {"a": "LOOOL ifa"}}},
+        ),
+    ],
+)
+async def test_issue381_output_coercion_on_union(
+    ttftt_engine_union, query, expected
+):
+    assert await ttftt_engine_union.execute(query) == expected

--- a/tests/functional/regressions/test_issue381.py
+++ b/tests/functional/regressions/test_issue381.py
@@ -19,6 +19,8 @@ async def ttftt_engine_union():
         aFieldUnionObj: CoupleOfResponses
         aFieldObj: CoupleOfResponsesNoUnionDir
         aFieldIfa: AnIfa
+        aFieldAnotherIfa: AnotherIfa
+        aFieldIfaNoDir: NoDirOnThisIface
     }
 
     union CoupleOfResponses @run_me_this_union = ResponseOne | ResponseTwo
@@ -28,11 +30,27 @@ async def ttftt_engine_union():
         a: String
     }
 
+    interface AnotherIfa @run_me_this_ifa {
+        a: String
+    }
+
+    interface NoDirOnThisIface {
+        a: String
+    }
+
     type ResponseOne @run_me_this_object {
         a: String
     }
 
     type ResponseThree implements AnIfa {
+        a: String
+    }
+
+    type ResponseFour implements AnotherIfa @run_me_this_object {
+        a: String
+    }
+
+    type ResponseFive implements NoDirOnThisIface @run_me_this_object {
         a: String
     }
 
@@ -68,6 +86,8 @@ async def ttftt_engine_union():
     @Resolver("Query.aFieldUnionObj", schema_name=schema_name)
     @Resolver("Query.aFieldObj", schema_name=schema_name)
     @Resolver("Query.aFieldIfa", schema_name=schema_name)
+    @Resolver("Query.aFieldAnotherIfa", schema_name=schema_name)
+    @Resolver("Query.aFieldIfaNoDir", schema_name=schema_name)
     async def resolve_root_query_field(pr, args, ctx, info):
         return {"a": "LOOOL"}
 
@@ -81,6 +101,14 @@ async def ttftt_engine_union():
     @TypeResolver("AnIfa", schema_name=schema_name)
     def resolve_type_ifa(result, context, info, abstract_type):
         return "ResponseThree"
+
+    @TypeResolver("AnotherIfa", schema_name=schema_name)
+    def resolve_type_ifa(result, context, info, abstract_type):
+        return "ResponseFour"
+
+    @TypeResolver("NoDirOnThisIface", schema_name=schema_name)
+    def resolve_type_ifa(result, context, info, abstract_type):
+        return "ResponseFive"
 
     return await create_engine(sdl=sdl, schema_name=schema_name)
 
@@ -122,6 +150,26 @@ query {
 }
             """,
             {"data": {"aFieldIfa": {"a": "LOOOL ifa"}}},
+        ),
+        (
+            """
+query {
+    aFieldAnotherIfa {
+        ...on ResponseFour { a }
+    }
+}
+            """,
+            {"data": {"aFieldAnotherIfa": {"a": "LOOOL ifa obj"}}},
+        ),
+        (
+            """
+query {
+    aFieldIfaNoDir {
+        ...on ResponseFive { a }
+    }
+}
+            """,
+            {"data": {"aFieldIfaNoDir": {"a": "LOOOL obj"}}},
         ),
     ],
 )

--- a/tests/functional/regressions/test_issue381.py
+++ b/tests/functional/regressions/test_issue381.py
@@ -1,0 +1,68 @@
+import pytest
+
+from tartiflette import Directive, Resolver, TypeResolver, create_engine
+
+_SDL = """ schema {
+  query: Query
+}
+
+directive @run_me_this on OBJECT
+
+type Query {
+  rootQueryField(resp: Int): CoupleOfResponses
+}
+
+union CoupleOfResponses = ResponseOne | ResponseTwo
+
+type ResponseOne @run_me_this {
+    a: String
+}
+
+
+type ResponseTwo {
+   b: Int
+}
+"""
+
+
+@Directive(name="run_me_this", schema_name="test_issue381")
+class RunMeThis:
+    async def on_pre_output_coercion(
+        self, directive_args, next_directive, value, ctx, info
+    ):
+        bob = await next_directive(value, ctx, info)
+        return {"a": f"{bob['a']} 2"}
+
+
+@Resolver("Query.rootQueryField", schema_name="test_issue381")
+async def resolve_root_query_field(pr, args, ctx, info):
+    return {"a": "LOOOL "}
+
+
+@TypeResolver("CoupleOfResponses", schema_name="test_issue381")
+def resolve_type_couple_of_responses(result, context, info, abstract_type):
+    if "a" in result:
+        return "ResponseOne"
+    return "ResponseTwo"
+
+
+@pytest.mark.asyncio
+async def test_issue381_output_coercion_on_union():
+    e = await create_engine(sdl=_SDL, schema_name="test_issue381")
+    assert (
+        await e.execute(
+            """
+query {
+    rootQueryField(resp: 1) {
+        ...on ResponseOne {
+            a
+        }
+        ...on ResponseTwo {
+            b
+        }
+    }
+}
+"""
+        )
+        == {"data": {"rootQueryField": {"a": "LOOOL  2"}}}
+    )


### PR DESCRIPTION
closes #381 

The idea is to calls the coercion of the runtimeType when union complete object is done. 
It does some reg, on 4 tests that I will investigate, but maybe @Maximilien-R you can already give me feedbacks on it, if you think its not to stupid.

Coercing the Union -> complete the object -> coerce_the_object (maybe it will call complete object to much :/) -> call the directive on the object. I don't know if I'm really clear on this @Maximilien-R ?

I'll continue to dive In.

