### PR TITLE
Remove reference to coercer in CHANGED changelog of 1.2.0

### DIFF
--- a/changelogs/1.2.0.md
+++ b/changelogs/1.2.0.md
@@ -10,10 +10,9 @@
 ## Changed
 
 - [ISSUE-356](https://github.com/dailymotion/tartiflette/issues/362) - Removed dependencies on `flex` and `bison` for installing Tartiflette. `cmake` is still necessary.
-- [ISSUE-361](https://github.com/dailymotion/tartiflette/issues/361) - Coerce lists (input, literal, output) synchronously to avoid creation of too many `asyncio` tasks.
 - [ISSUE-365](https://github.com/dailymotion/tartiflette/issues/365) - Forward the `InputValueDefinitionNode` to the `on_argument_execution` hook.
-  > Note: this brings a break changes from previous versions, to upgrade to
-  > this version you'll have to update your `on_argument_execution` methods:
+  > Note: this introduces a breaking change from previous versions, to upgrade
+  > to this version you'll have to update your `on_argument_execution` methods:
   ````patch
   @Directive("MyDirective")
   class MyDirective:


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [ ] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~ Not applicable for this PR.
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable for this PR.
* [x] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*


1.2.0 introduced a way to provide a custom arguments coercer. The `CHANGED` entry in the changelog is a bit misleading, as it could make people think that the default behaviour has changed, whereas the default is the same, and the feature is already documented in the `ADDED` part or the changelog.