### PR TITLE
[v2] Improve pre output coercion directive hooks

### DIFF
--- a/tartiflette/coercers/outputs/abstract_coercer.py
+++ b/tartiflette/coercers/outputs/abstract_coercer.py
@@ -108,6 +108,7 @@ async def abstract_coercer(
 
     return await complete_object_value(
         await runtime_type.pre_output_coercion_directives(
+            runtime_type.definition,
             result,
             execution_context.context,
             info,

--- a/tartiflette/coercers/outputs/directives_coercer.py
+++ b/tartiflette/coercers/outputs/directives_coercer.py
@@ -11,6 +11,7 @@ async def output_directives_coercer(
     path: "Path",
     coercer: Callable,
     directives: Callable,
+    definition_node: "Node",
 ) -> Any:
     """
     Executes the directives on the resolved value.
@@ -21,6 +22,7 @@ async def output_directives_coercer(
     :param path: the path traveled until this resolver
     :param coercer: pre-computed coercer to use on the value
     :param directives: the directives to execute
+    :param definition_node: the definition AST node to coerce
     :type result: Any
     :type info: ResolveInfo
     :type execution_context: ExecutionContext
@@ -28,11 +30,13 @@ async def output_directives_coercer(
     :type path: Path
     :type coercer: Callable
     :type directives: Callable
+    :type definition_node: Node
     :return: the coerced result
     :rtype: Any
     """
     return await coercer(
         await directives(
+            definition_node,
             result,
             execution_context.context,
             info,

--- a/tartiflette/coercers/outputs/enum_coercer.py
+++ b/tartiflette/coercers/outputs/enum_coercer.py
@@ -37,6 +37,7 @@ async def enum_coercer(
     try:
         enum_value = enum_type.get_value(result)
         coerced_result = await enum_value.output_coercer(
+            enum_value.definition,
             result,
             execution_context.context,
             info,

--- a/tartiflette/schema/schema.py
+++ b/tartiflette/schema/schema.py
@@ -44,6 +44,12 @@ _DEFAULT_SUBSCRIPTION_OPERATION_NAME = "Subscription"
 
 _IMPLEMENTABLE_DIRECTIVE_FUNCTION_HOOKS = (
     "on_post_bake",
+    "on_pre_interface_output_coercion",
+    "on_pre_object_output_coercion",
+    "on_pre_union_output_coercion",
+    "on_pre_enum_type_output_coercion",
+    "on_pre_enum_value_output_coercion",
+    "on_pre_scalar_output_coercion",
     "on_pre_output_coercion",
     "on_introspection",
     "on_post_input_object_coercion",

--- a/tartiflette/schema/transformer.py
+++ b/tartiflette/schema/transformer.py
@@ -436,6 +436,7 @@ def parse_object_type_definition(
             object_type_definition_node.fields, schema
         ),
         directives=object_type_definition_node.directives,
+        definition=object_type_definition_node,
     )
     schema.add_type_definition(object_type)
     return object_type
@@ -517,6 +518,7 @@ def parse_interface_type_definition(
             interface_type_definition_node.fields, schema
         ),
         directives=interface_type_definition_node.directives,
+        definition=interface_type_definition_node,
     )
     schema.add_type_definition(interface_type)
     return interface_type
@@ -567,6 +569,7 @@ def parse_union_type_definition(
             union_type_definition_node.types, schema
         ),
         directives=union_type_definition_node.directives,
+        definition=union_type_definition_node,
     )
     schema.add_type_definition(union_type)
     return union_type

--- a/tartiflette/types/enum.py
+++ b/tartiflette/types/enum.py
@@ -27,6 +27,7 @@ from tartiflette.types.type import (
 )
 from tartiflette.utils.directives import (
     default_post_input_coercion_directive,
+    default_pre_output_coercion_directive,
     wraps_with_directives,
 )
 
@@ -156,8 +157,11 @@ class GraphQLEnumValue:
         self.literal_coercer = post_input_coercion_directives
         self.output_coercer = wraps_with_directives(
             directives_definition=directives_definition,
-            directive_hooks=["on_pre_output_coercion"],
-            with_default=True,
+            directive_hooks=[
+                "on_pre_enum_value_output_coercion",
+                "on_pre_output_coercion",
+            ],
+            func=default_pre_output_coercion_directive,
         )
 
 
@@ -316,9 +320,13 @@ class GraphQLEnumType(GraphQLInputType, GraphQLType):
             coercer=partial(enum_coercer, enum_type=self),
             directives=wraps_with_directives(
                 directives_definition=directives_definition,
-                directive_hooks=["on_pre_output_coercion"],
-                with_default=True,
+                directive_hooks=[
+                    "on_pre_enum_type_output_coercion",
+                    "on_pre_output_coercion",
+                ],
+                func=default_pre_output_coercion_directive,
             ),
+            definition_node=self.definition,
         )
 
     async def bake_enum_values(self, schema: "GraphQLSchema") -> None:

--- a/tartiflette/types/scalar.py
+++ b/tartiflette/types/scalar.py
@@ -27,6 +27,7 @@ from tartiflette.types.type import (
 )
 from tartiflette.utils.directives import (
     default_post_input_coercion_directive,
+    default_pre_output_coercion_directive,
     wraps_with_directives,
 )
 
@@ -152,9 +153,13 @@ class GraphQLScalarType(GraphQLInputType, GraphQLType):
             coercer=partial(scalar_coercer, scalar_type=self),
             directives=wraps_with_directives(
                 directives_definition=directives_definition,
-                directive_hooks=["on_pre_output_coercion"],
-                with_default=True,
+                directive_hooks=[
+                    "on_pre_scalar_output_coercion",
+                    "on_pre_output_coercion",
+                ],
+                func=default_pre_output_coercion_directive,
             ),
+            definition_node=self.definition,
         )
 
 

--- a/tartiflette/utils/directives.py
+++ b/tartiflette/utils/directives.py
@@ -9,6 +9,7 @@ from tartiflette.utils.values import is_invalid_value
 __all__ = (
     "introspection_directives_executor",
     "default_post_input_coercion_directive",
+    "default_pre_output_coercion_directive",
     "wraps_with_directives",
 )
 
@@ -124,6 +125,40 @@ async def default_post_input_coercion_directive(
     ]
     :type value: Any
     :return: the coerced value of the input
+    :rtype: Any
+    """
+    # pylint: disable=unused-argument
+    return value
+
+
+async def default_pre_output_coercion_directive(
+    output_definition_node: Union[
+        "InterfaceTypeDefinitionNode",
+        "ObjectTypeDefinitionNode",
+        "UnionTypeDefinitionNode",
+        "EnumTypeDefinitionNode",
+        "EnumValueDefinitionNode",
+        "ScalarTypeDefinitionNode",
+    ],
+    value: Any,
+    *args,
+    **kwargs,
+) -> Any:
+    """
+    Default callable to use to wrap with directives on `on_pre_output_coercion`
+    hook name.
+    :param output_definition_node: the input definition AST node
+    :param value: the coerced value of the argument
+    :type output_definition_node: Union[
+        InterfaceTypeDefinitionNode,
+        ObjectTypeDefinitionNode,
+        UnionTypeDefinitionNode,
+        EnumTypeDefinitionNode,
+        EnumValueDefinitionNode,
+        ScalarTypeDefinitionNode,
+    ]
+    :type value: Any
+    :return: the coerced value of the output
     :rtype: Any
     """
     # pylint: disable=unused-argument

--- a/tests/functional/regressions/issue278/test_issue278_extend_enum.py
+++ b/tests/functional/regressions/issue278/test_issue278_extend_enum.py
@@ -14,11 +14,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            value = await next_directive(value, ctx, info)
+            value = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             if value == directive_args.get("oldValue"):
                 return directive_args["newValue"]
             if not directive_args.get("oldValue"):

--- a/tests/functional/regressions/issue278/test_issue278_extend_object.py
+++ b/tests/functional/regressions/issue278/test_issue278_extend_object.py
@@ -14,11 +14,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            value = await next_directive(value, ctx, info)
+            value = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             value.update(directive_args["newValue"])
             return value
 

--- a/tests/functional/regressions/issue278/test_issue278_extend_scalar.py
+++ b/tests/functional/regressions/issue278/test_issue278_extend_scalar.py
@@ -14,12 +14,13 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
             return (
-                await next_directive(value, ctx, info)
+                await next_directive(output_definition_node, value, ctx, info)
                 + directive_args["value"]
             )
 

--- a/tests/functional/regressions/test_input_directives.py
+++ b/tests/functional/regressions/test_input_directives.py
@@ -50,11 +50,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            return await next_directive(value, ctx, info)
+            return await next_directive(
+                output_definition_node, value, ctx, info
+            )
 
     @Directive("error", schema_name=schema_name)
     class ErrorDirective:
@@ -84,6 +87,7 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",

--- a/tests/functional/regressions/test_issue223.py
+++ b/tests/functional/regressions/test_issue223.py
@@ -32,12 +32,15 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
             value["value"] = value["value"] + directive_args["value"]
-            return await next_directive(value, ctx, info)
+            return await next_directive(
+                output_definition_node, value, ctx, info
+            )
 
     @Directive("mapToValue", schema_name=schema_name)
     class MapToValue:
@@ -47,12 +50,15 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
             value = MapToValue.my_map.get(value, value)
-            return await next_directive(value, ctx, info)
+            return await next_directive(
+                output_definition_node, value, ctx, info
+            )
 
         @staticmethod
         async def on_post_input_coercion(
@@ -97,11 +103,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            return await next_directive(value.capitalize(), ctx, info)
+            return await next_directive(
+                output_definition_node, value.capitalize(), ctx, info
+            )
 
     @Directive("lower", schema_name=schema_name)
     @Directive("lower2", schema_name=schema_name)
@@ -110,11 +119,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            return await next_directive(value.lower(), ctx, info)
+            return await next_directive(
+                output_definition_node, value.lower(), ctx, info
+            )
 
     @Directive("upper", schema_name=schema_name)
     class Upper:
@@ -122,11 +134,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            return await next_directive(value.upper(), ctx, info)
+            return await next_directive(
+                output_definition_node, value.upper(), ctx, info
+            )
 
     @Resolver("Query.wardrobe", schema_name=schema_name)
     async def wardrobe_resolver(_pr, _args, _ctx, _info):

--- a/tests/functional/regressions/test_issue233.py
+++ b/tests/functional/regressions/test_issue233.py
@@ -55,11 +55,14 @@ def bakery(schema_name):
         async def on_pre_output_coercion(
             directive_args: Dict[str, Any],
             next_directive: Callable,
+            output_definition_node,
             value: Any,
             ctx: Optional[Any],
             info: "ResolveInfo",
         ):
-            value = await next_directive(value, ctx, info)
+            value = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             if value is None:
                 return value
 

--- a/tests/functional/regressions/test_issue381.py
+++ b/tests/functional/regressions/test_issue381.py
@@ -7,25 +7,49 @@ def bakery(schema_name):
     @Directive(name="run_me_this_object", schema_name=schema_name)
     class RunMeThisObject:
         async def on_pre_output_coercion(
-            self, directive_args, next_directive, value, ctx, info
+            self,
+            directive_args,
+            next_directive,
+            output_definition_node,
+            value,
+            ctx,
+            info,
         ):
-            bob = await next_directive(value, ctx, info)
+            bob = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             return {"a": f"{bob['a']} obj"}
 
     @Directive(name="run_me_this_union", schema_name=schema_name)
     class RunMeThisUnion:
         async def on_pre_output_coercion(
-            self, directive_args, next_directive, value, ctx, info
+            self,
+            directive_args,
+            next_directive,
+            output_definition_node,
+            value,
+            ctx,
+            info,
         ):
-            bob = await next_directive(value, ctx, info)
+            bob = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             return {"a": f"{bob['a']} union"}
 
     @Directive(name="run_me_this_ifa", schema_name=schema_name)
     class RunMeThisIfa:
         async def on_pre_output_coercion(
-            self, directive_args, next_directive, value, ctx, info
+            self,
+            directive_args,
+            next_directive,
+            output_definition_node,
+            value,
+            ctx,
+            info,
         ):
-            bob = await next_directive(value, ctx, info)
+            bob = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             return {"a": f"{bob['a']} ifa"}
 
     @Resolver("Query.aFieldUnionObj", schema_name=schema_name)

--- a/tests/functional/test_directives_went_through.py
+++ b/tests/functional/test_directives_went_through.py
@@ -154,10 +154,77 @@ def bakery(schema_name):
             return result
 
         @staticmethod
-        async def on_pre_output_coercion(
-            directive_args, next_directive, value, ctx, info,
+        async def on_pre_interface_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
         ):
-            result = await next_directive(value, ctx, info)
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_interface_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_object_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
+        ):
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_object_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_union_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
+        ):
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_union_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_enum_type_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
+        ):
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_enum_type_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_enum_value_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
+        ):
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_enum_value_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_scalar_output_coercion(
+            directive_args, next_directive, definition_node, value, ctx, info,
+        ):
+            result = await next_directive(definition_node, value, ctx, info)
+            ctx["went_through"].append(
+                f"wentThrough.on_pre_scalar_output_coercion {directive_args['over']}"
+            )
+            return result
+
+        @staticmethod
+        async def on_pre_output_coercion(
+            directive_args,
+            next_directive,
+            output_definition_node,
+            value,
+            ctx,
+            info,
+        ):
+            result = await next_directive(
+                output_definition_node, value, ctx, info
+            )
             ctx["went_through"].append(
                 f"wentThrough.on_pre_output_coercion {directive_args['over']}"
             )
@@ -166,6 +233,19 @@ def bakery(schema_name):
     @Resolver("Query.human", schema_name=schema_name)
     async def resolver_query_human(parent, args, ctx, info):
         return {"id": "1", "name": "Human", "gender": "FEMALE"}
+
+    @Resolver("Query.identifiable", schema_name=schema_name)
+    async def resolver_query_identifiable(parent, args, ctx, info):
+        return {"_typename": "Human", "id": "1"}
+
+    @Resolver("Query.individual", schema_name=schema_name)
+    async def resolver_query_individual(parent, args, ctx, info):
+        return {
+            "_typename": "Human",
+            "id": "1",
+            "name": "Human",
+            "gender": "FEMALE",
+        }
 
     Scalar("DefaultRawString", schema_name=schema_name)(StringScalar())
 
@@ -209,6 +289,11 @@ def bakery(schema_name):
       gender: Gender! @wentThrough(over: "Human.gender")
     }
 
+    type Alien implements Identifiable & Named @wentThrough(over: "Alien") {
+      id: ID! @wentThrough(over: "Alien.id")
+      name: String! @wentThrough(over: "Alien.name")
+    }
+
     input TextFilter @wentThrough(over: "TextFilter") {
       startsWith: String @wentThrough(over: "TextFilter.startsWith")
       equals: String @wentThrough(over: "TextFilter.equals")
@@ -220,10 +305,16 @@ def bakery(schema_name):
       gender: Gender @wentThrough(over: "HumanFilter.gender")
     }
 
+    union Individual @wentThrough(over: "Individual") = Alien | Human
+
     type Query @wentThrough(over: "Query") {
       human(
         filter: HumanFilter @wentThrough(over: "Query.human(filter:)")
       ): Human @wentThrough(over: "Query.human")
+
+      identifiable(id: ID!): Identifiable
+
+      individual(id: ID!): Individual
     }
 
     schema @wentThrough(over: "Schema") {
@@ -260,11 +351,11 @@ def bakery(schema_name):
                 }
             },
             [
-                "wentThrough.on_post_scalar_input_coercion ID",
                 "wentThrough.on_post_enum_value_input_coercion Gender.FEMALE",
+                "wentThrough.on_post_scalar_input_coercion ID",
                 "wentThrough.on_post_scalar_input_coercion String",
-                "wentThrough.on_post_input_field_coercion HumanFilter.id",
                 "wentThrough.on_post_enum_type_input_coercion Gender",
+                "wentThrough.on_post_input_field_coercion HumanFilter.id",
                 "wentThrough.on_post_input_field_coercion TextFilter.equals",
                 "wentThrough.on_post_input_field_coercion HumanFilter.gender",
                 "wentThrough.on_post_input_object_coercion TextFilter",
@@ -272,14 +363,14 @@ def bakery(schema_name):
                 "wentThrough.on_post_input_object_coercion HumanFilter",
                 "wentThrough.on_post_argument_coercion Query.human(filter:)",
                 "wentThrough.on_field_execution Query.human",
-                "wentThrough.on_pre_output_coercion Human",
+                "wentThrough.on_pre_object_output_coercion Human",
                 "wentThrough.on_field_execution Human.id",
-                "wentThrough.on_field_execution Human.gender",
                 "wentThrough.on_field_execution Human.name",
-                "wentThrough.on_pre_output_coercion ID",
-                "wentThrough.on_pre_output_coercion Gender",
-                "wentThrough.on_pre_output_coercion String",
-                "wentThrough.on_pre_output_coercion Gender.FEMALE",
+                "wentThrough.on_field_execution Human.gender",
+                "wentThrough.on_pre_scalar_output_coercion ID",
+                "wentThrough.on_pre_scalar_output_coercion String",
+                "wentThrough.on_pre_enum_type_output_coercion Gender",
+                "wentThrough.on_pre_enum_value_output_coercion Gender.FEMALE",
                 "wentThrough.on_schema_execution Schema",
             ],
         ),
@@ -318,14 +409,78 @@ def bakery(schema_name):
                 "wentThrough.on_post_input_object_coercion HumanFilter",
                 "wentThrough.on_post_argument_coercion Query.human(filter:)",
                 "wentThrough.on_field_execution Query.human",
-                "wentThrough.on_pre_output_coercion Human",
+                "wentThrough.on_pre_object_output_coercion Human",
                 "wentThrough.on_field_execution Human.name",
                 "wentThrough.on_field_execution Human.gender",
                 "wentThrough.on_field_execution Human.id",
-                "wentThrough.on_pre_output_coercion String",
-                "wentThrough.on_pre_output_coercion Gender",
-                "wentThrough.on_pre_output_coercion ID",
-                "wentThrough.on_pre_output_coercion Gender.FEMALE",
+                "wentThrough.on_pre_scalar_output_coercion String",
+                "wentThrough.on_pre_enum_type_output_coercion Gender",
+                "wentThrough.on_pre_scalar_output_coercion ID",
+                "wentThrough.on_pre_enum_value_output_coercion Gender.FEMALE",
+                "wentThrough.on_schema_execution Schema",
+            ],
+        ),
+        (
+            """
+            {
+              identifiable(id: "1") {
+                __typename
+                id
+              }
+            }
+            """,
+            {},
+            {"data": {"identifiable": {"__typename": "Human", "id": "1"}}},
+            [
+                "wentThrough.on_post_scalar_input_coercion ID",
+                "wentThrough.on_pre_interface_output_coercion Interface",
+                "wentThrough.on_pre_object_output_coercion Human",
+                "wentThrough.on_field_execution Human.id",
+                "wentThrough.on_pre_scalar_output_coercion String",
+                "wentThrough.on_pre_scalar_output_coercion ID",
+                "wentThrough.on_schema_execution Schema",
+            ],
+        ),
+        (
+            """
+            {
+              individual(id: "1") {
+                __typename
+                ... on Alien {
+                  id
+                  name
+                }
+                ... on Human {
+                  id
+                  name
+                  gender
+                }
+              }
+            }
+            """,
+            {},
+            {
+                "data": {
+                    "individual": {
+                        "__typename": "Human",
+                        "id": "1",
+                        "name": "Human",
+                        "gender": "FEMALE",
+                    }
+                }
+            },
+            [
+                "wentThrough.on_post_scalar_input_coercion ID",
+                "wentThrough.on_pre_union_output_coercion Individual",
+                "wentThrough.on_pre_object_output_coercion Human",
+                "wentThrough.on_pre_scalar_output_coercion String",
+                "wentThrough.on_field_execution Human.name",
+                "wentThrough.on_field_execution Human.gender",
+                "wentThrough.on_field_execution Human.id",
+                "wentThrough.on_pre_scalar_output_coercion String",
+                "wentThrough.on_pre_enum_type_output_coercion Gender",
+                "wentThrough.on_pre_scalar_output_coercion ID",
+                "wentThrough.on_pre_enum_value_output_coercion Gender.FEMALE",
                 "wentThrough.on_schema_execution Schema",
             ],
         ),


### PR DESCRIPTION
As it was done with https://github.com/tartiflette/tartiflette/pull/430 for post input coercion, the goal of this PR is to provide more granular directive hooks for the pre output coercion with a fallback on the existing `on_pre_output_coercion` hook.

Also, as done for post input coercion, the prototype has been changed in order to provide the output type definition node:
```diff
@Directive("myDirective")
class MyDirective:
    @staticmethod
    async def on_pre_output_coercion(
        directive_args,
        next_directive,
+        output_definition_node,
        value,
        ctx,
    ):
        pass
```