### PR TITLE
[v2] Extends GraphQL types definition nodes at extensions bake

### DIFF
--- a/tartiflette/language/ast/enum_type_definition.py
+++ b/tartiflette/language/ast/enum_type_definition.py
@@ -1,6 +1,7 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.enum_type_extension import EnumTypeExtensionNode
 
 __all__ = ("EnumTypeDefinitionNode",)
 
@@ -34,8 +35,8 @@ class EnumTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.directives = directives
-        self.values = values
+        self.directives = directives or []
+        self.values = values or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -54,6 +55,25 @@ class EnumTypeDefinitionNode(TypeDefinitionNode):
             and self.values == other.values
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "EnumTypeDefinitionNode":
+        """
+        Return a new enum definition with elements from extension.
+
+        :param extension: instance with which extend the enum
+        :type extension: Any
+        :return: a new enum definition with elements from extension
+        :rtype: EnumTypeDefinitionNode
+        """
+        if isinstance(extension, EnumTypeExtensionNode):
+            return EnumTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                directives=self.directives + extension.directives,
+                values=self.values + extension.values,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/enum_type_extension.py
+++ b/tartiflette/language/ast/enum_type_extension.py
@@ -30,8 +30,8 @@ class EnumTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.directives = directives
-        self.values = values
+        self.directives = directives or []
+        self.values = values or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/language/ast/input_object_type_definition.py
+++ b/tartiflette/language/ast/input_object_type_definition.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.input_object_type_extension import (
+    InputObjectTypeExtensionNode,
+)
 
 __all__ = ("InputObjectTypeDefinitionNode",)
 
@@ -35,8 +38,8 @@ class InputObjectTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.directives = directives
-        self.fields = fields
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -55,6 +58,25 @@ class InputObjectTypeDefinitionNode(TypeDefinitionNode):
             and self.fields == other.fields
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "InputObjectTypeDefinitionNode":
+        """
+        Return a new input definition with elements from extension.
+
+        :param extension: instance with which extend the input
+        :type extension: Any
+        :return: a new input definition with elements from extension
+        :rtype: InputObjectTypeDefinitionNode
+        """
+        if isinstance(extension, InputObjectTypeExtensionNode):
+            return InputObjectTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                directives=self.directives + extension.directives,
+                fields=self.fields + extension.fields,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/input_object_type_extension.py
+++ b/tartiflette/language/ast/input_object_type_extension.py
@@ -31,8 +31,8 @@ class InputObjectTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.directives = directives
-        self.fields = fields
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/language/ast/interface_type_definition.py
+++ b/tartiflette/language/ast/interface_type_definition.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.interface_type_extension import (
+    InterfaceTypeExtensionNode,
+)
 
 __all__ = ("InterfaceTypeDefinitionNode",)
 
@@ -35,8 +38,8 @@ class InterfaceTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.directives = directives
-        self.fields = fields
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -55,6 +58,25 @@ class InterfaceTypeDefinitionNode(TypeDefinitionNode):
             and self.fields == other.fields
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "InterfaceTypeDefinitionNode":
+        """
+        Return a new interface definition with elements from extension.
+
+        :param extension: instance with which extend the interface
+        :type extension: Any
+        :return: a new interface definition with elements from extension
+        :rtype: InterfaceTypeDefinitionNode
+        """
+        if isinstance(extension, InterfaceTypeExtensionNode):
+            return InterfaceTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                directives=self.directives + extension.directives,
+                fields=self.fields + extension.fields,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/interface_type_extension.py
+++ b/tartiflette/language/ast/interface_type_extension.py
@@ -31,8 +31,8 @@ class InterfaceTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.directives = directives
-        self.fields = fields
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/language/ast/object_type_definition.py
+++ b/tartiflette/language/ast/object_type_definition.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.object_type_extension import (
+    ObjectTypeExtensionNode,
+)
 
 __all__ = ("ObjectTypeDefinitionNode",)
 
@@ -45,9 +48,9 @@ class ObjectTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.interfaces = interfaces
-        self.directives = directives
-        self.fields = fields
+        self.interfaces = interfaces or []
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -67,6 +70,26 @@ class ObjectTypeDefinitionNode(TypeDefinitionNode):
             and self.fields == other.fields
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "ObjectTypeDefinitionNode":
+        """
+        Return a new object definition with elements from extension.
+
+        :param extension: instance with which extend the object
+        :type extension: Any
+        :return: a new object definition with elements from extension
+        :rtype: ObjectTypeDefinitionNode
+        """
+        if isinstance(extension, ObjectTypeExtensionNode):
+            return ObjectTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                interfaces=self.interfaces + extension.interfaces,
+                directives=self.directives + extension.directives,
+                fields=self.fields + extension.fields,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/object_type_extension.py
+++ b/tartiflette/language/ast/object_type_extension.py
@@ -33,9 +33,9 @@ class ObjectTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.interfaces = interfaces
-        self.directives = directives
-        self.fields = fields
+        self.interfaces = interfaces or []
+        self.directives = directives or []
+        self.fields = fields or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/language/ast/scalar_type_definition.py
+++ b/tartiflette/language/ast/scalar_type_definition.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.scalar_type_extension import (
+    ScalarTypeExtensionNode,
+)
 
 __all__ = ("ScalarTypeDefinitionNode",)
 
@@ -32,7 +35,7 @@ class ScalarTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.directives = directives
+        self.directives = directives or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -50,6 +53,24 @@ class ScalarTypeDefinitionNode(TypeDefinitionNode):
             and self.directives == other.directives
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "ScalarTypeDefinitionNode":
+        """
+        Return a new scalar definition with elements from extension.
+
+        :param extension: instance with which extend the scalar
+        :type extension: Any
+        :return: a new scalar definition with elements from extension
+        :rtype: ScalarTypeDefinitionNode
+        """
+        if isinstance(extension, ScalarTypeExtensionNode):
+            return ScalarTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                directives=self.directives + extension.directives,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/scalar_type_extension.py
+++ b/tartiflette/language/ast/scalar_type_extension.py
@@ -27,7 +27,7 @@ class ScalarTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.directives = directives
+        self.directives = directives or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/language/ast/union_type_definition.py
+++ b/tartiflette/language/ast/union_type_definition.py
@@ -1,6 +1,9 @@
 from typing import Any, List, Optional
 
 from tartiflette.language.ast.base import TypeDefinitionNode
+from tartiflette.language.ast.union_type_extension import (
+    UnionTypeExtensionNode,
+)
 
 __all__ = ("UnionTypeDefinitionNode",)
 
@@ -34,8 +37,8 @@ class UnionTypeDefinitionNode(TypeDefinitionNode):
         """
         self.name = name
         self.description = description
-        self.directives = directives
-        self.types = types
+        self.directives = directives or []
+        self.types = types or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:
@@ -54,6 +57,25 @@ class UnionTypeDefinitionNode(TypeDefinitionNode):
             and self.types == other.types
             and self.location == other.location
         )
+
+    def __or__(self, extension: Any) -> "UnionTypeDefinitionNode":
+        """
+        Return a new union definition with elements from extension.
+
+        :param extension: instance with which extend the union
+        :type extension: Any
+        :return: a new union definition with elements from extension
+        :rtype: UnionTypeDefinitionNode
+        """
+        if isinstance(extension, UnionTypeExtensionNode):
+            return UnionTypeDefinitionNode(
+                name=self.name,
+                description=self.description,
+                directives=self.directives + extension.directives,
+                types=self.types + extension.types,
+                location=self.location,
+            )
+        return self
 
     def __repr__(self) -> str:
         """

--- a/tartiflette/language/ast/union_type_extension.py
+++ b/tartiflette/language/ast/union_type_extension.py
@@ -30,8 +30,8 @@ class UnionTypeExtensionNode(TypeExtensionNode):
         :type location: Optional[Location]
         """
         self.name = name
-        self.directives = directives
-        self.types = types
+        self.directives = directives or []
+        self.types = types or []
         self.location = location
 
     def __eq__(self, other: Any) -> bool:

--- a/tartiflette/schema/transformer.py
+++ b/tartiflette/schema/transformer.py
@@ -263,7 +263,7 @@ def parse_input_value_definition(
         ),
         gql_type=parse_type(input_value_definition_node.type, schema),
         default_value=input_value_definition_node.default_value,
-        directives=input_value_definition_node.directives,
+        directives=list(input_value_definition_node.directives),
         definition=input_value_definition_node,
     )
 
@@ -352,7 +352,7 @@ def parse_schema_definition(
     parse_operation_type_definitions(
         schema_definition_node.operation_type_definitions, schema
     )
-    schema.add_schema_directives(schema_definition_node.directives)
+    schema.add_schema_directives(list(schema_definition_node.directives))
 
 
 def parse_scalar_type_definition(
@@ -378,7 +378,7 @@ def parse_scalar_type_definition(
         description=parse_name(
             scalar_type_definition_node.description, schema
         ),
-        directives=scalar_type_definition_node.directives,
+        directives=list(scalar_type_definition_node.directives),
         definition=scalar_type_definition_node,
     )
     schema.add_scalar_definition(scalar_type)
@@ -435,7 +435,7 @@ def parse_object_type_definition(
         fields=parse_fields_definition(
             object_type_definition_node.fields, schema
         ),
-        directives=object_type_definition_node.directives,
+        directives=list(object_type_definition_node.directives),
         definition=object_type_definition_node,
     )
     schema.add_type_definition(object_type)
@@ -464,7 +464,7 @@ def parse_field_definition(
         arguments=parse_arguments_definition(
             field_definition_node.arguments, schema
         ),
-        directives=field_definition_node.directives,
+        directives=list(field_definition_node.directives),
     )
 
 
@@ -517,7 +517,7 @@ def parse_interface_type_definition(
         fields=parse_fields_definition(
             interface_type_definition_node.fields, schema
         ),
-        directives=interface_type_definition_node.directives,
+        directives=list(interface_type_definition_node.directives),
         definition=interface_type_definition_node,
     )
     schema.add_type_definition(interface_type)
@@ -568,7 +568,7 @@ def parse_union_type_definition(
         types=parse_union_member_types(
             union_type_definition_node.types, schema
         ),
-        directives=union_type_definition_node.directives,
+        directives=list(union_type_definition_node.directives),
         definition=union_type_definition_node,
     )
     schema.add_type_definition(union_type)
@@ -594,7 +594,7 @@ def parse_enum_value_definition(
     return GraphQLEnumValue(
         value=parse_name(enum_value_definition_node.name, schema),
         description=parse_name(enum_value_definition_node.description, schema),
-        directives=enum_value_definition_node.directives,
+        directives=list(enum_value_definition_node.directives),
         definition=enum_value_definition_node,
     )
 
@@ -644,7 +644,7 @@ def parse_enum_type_definition(
         values=parse_enum_values_definition(
             enum_type_definition_node.values, schema
         ),
-        directives=enum_type_definition_node.directives,
+        directives=list(enum_type_definition_node.directives),
         definition=enum_type_definition_node,
     )
     schema.add_enum_definition(enum_type)
@@ -705,7 +705,7 @@ def parse_input_object_type_definition(
         fields=parse_input_fields_definition(
             input_object_type_definition_node.fields, schema
         ),
-        directives=input_object_type_definition_node.directives,
+        directives=list(input_object_type_definition_node.directives),
         definition=input_object_type_definition_node,
     )
     schema.add_type_definition(input_object_type)
@@ -776,10 +776,11 @@ def parse_enum_type_extension(
 
     enum_extension = GraphQLEnumTypeExtension(
         name=parse_name(enum_type_extension_node.name, schema),
-        directives=enum_type_extension_node.directives,
+        directives=list(enum_type_extension_node.directives),
         values=parse_enum_values_definition(
             enum_type_extension_node.values, schema
         ),
+        definition=enum_type_extension_node,
     )
 
     schema.add_extension(enum_extension)
@@ -794,10 +795,11 @@ def parse_input_object_type_extension(
 
     input_object_extenstion = GraphQLInputObjectTypeExtension(
         name=parse_name(input_object_type_extension_node.name, schema),
-        directives=input_object_type_extension_node.directives,
+        directives=list(input_object_type_extension_node.directives),
         input_fields=parse_input_fields_definition(
             input_object_type_extension_node.fields, schema
         ),
+        definition=input_object_type_extension_node,
     )
 
     schema.add_extension(input_object_extenstion)
@@ -815,10 +817,11 @@ def parse_object_type_extension(
         fields=parse_fields_definition(
             object_type_extension_node.fields, schema
         ),
-        directives=object_type_extension_node.directives,
+        directives=list(object_type_extension_node.directives),
         interfaces=parse_implements_interfaces(
             object_type_extension_node.interfaces, schema
         ),
+        definition=object_type_extension_node,
     )
 
     schema.add_extension(object_extension)
@@ -836,7 +839,8 @@ def parse_interface_type_extension(
         fields=parse_fields_definition(
             interface_type_extension_node.fields, schema
         ),
-        directives=interface_type_extension_node.directives,
+        directives=list(interface_type_extension_node.directives),
+        definition=interface_type_extension_node,
     )
 
     schema.add_extension(interface_extension)
@@ -851,7 +855,8 @@ def parse_scalar_type_extension(
 
     scalar_extension = GraphQLScalarTypeExtension(
         name=parse_name(scalar_type_extension_node.name, schema),
-        directives=scalar_type_extension_node.directives,
+        directives=list(scalar_type_extension_node.directives),
+        definition=scalar_type_extension_node,
     )
 
     schema.add_extension(scalar_extension)
@@ -866,10 +871,11 @@ def parse_union_type_extension(
 
     union_extension = GraphQLUnionTypeExtension(
         name=parse_name(union_type_extension_node.name, schema),
-        directives=union_type_extension_node.directives,
+        directives=list(union_type_extension_node.directives),
         types=parse_union_member_types(
             union_type_extension_node.types, schema
         ),
+        definition=union_type_extension_node,
     )
 
     schema.add_extension(union_extension)
@@ -881,7 +887,7 @@ def parse_schema_extension(
     schema_extension_node: "SchemaExtensionNode", schema: "GraphQLSchema"
 ) -> "GraphQLSchemaExtension":
     schema_extension = GraphQLSchemaExtension(
-        directives=schema_extension_node.directives,
+        directives=list(schema_extension_node.directives),
         operations={
             x.operation_type: parse_named_type(x.type, schema)
             for x in schema_extension_node.operation_type_definitions

--- a/tartiflette/types/enum.py
+++ b/tartiflette/types/enum.py
@@ -194,7 +194,7 @@ class GraphQLEnumType(GraphQLInputType, GraphQLType):
         :type directives: Optional[List[DirectiveNode]]
         """
         self.name = name
-        self.values = values
+        self.values = values or []
         self.definition = definition
         self.description = description
         self._value_map: Dict[str, "GraphQLEnumValue"] = {}
@@ -342,15 +342,17 @@ class GraphQLEnumType(GraphQLInputType, GraphQLType):
 
 
 class GraphQLEnumTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, directives, values):
+    def __init__(self, name, directives, values, definition):
         self.name = name
         self.directives = directives
         self.values = values or []
+        self.definition = definition
 
     def bake(self, schema):
         enum = schema.find_type(self.name)
         enum.directives.extend(self.directives)
         enum.values.extend(self.values)
+        enum.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/input_object.py
+++ b/tartiflette/types/input_object.py
@@ -176,15 +176,17 @@ class GraphQLInputObjectType(GraphQLInputType, GraphQLType):
 
 
 class GraphQLInputObjectTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, input_fields, directives):
+    def __init__(self, name, input_fields, directives, definition):
         self.name = name
         self.input_fields = input_fields or {}
         self.directives = directives
+        self.definition = definition
 
     def bake(self, schema):
         extended = schema.find_type(self.name)
         extended.input_fields.update(self.input_fields)
         extended.directives.extend(self.directives)
+        extended.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/interface.py
+++ b/tartiflette/types/interface.py
@@ -229,16 +229,17 @@ class GraphQLInterfaceType(GraphQLAbstractType, GraphQLCompositeType):
 
 
 class GraphQLInterfaceTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, directives, fields):
+    def __init__(self, name, directives, fields, definition):
         self.name = name
         self.directives = directives
         self.fields = fields or []
+        self.definition = definition
 
     def bake(self, schema):
         extended = schema.find_type(self.name)
-
         extended.directives.extend(self.directives)
         extended.implemented_fields.update(self.fields)
+        extended.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/object.py
+++ b/tartiflette/types/object.py
@@ -210,17 +210,19 @@ class GraphQLObjectType(GraphQLCompositeType, GraphQLType):
 
 
 class GraphQLObjectTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, fields, directives, interfaces):
+    def __init__(self, name, fields, directives, interfaces, definition):
         self.name = name
         self.fields = fields or {}
         self.directives = directives
         self.interfaces = interfaces or []
+        self.definition = definition
 
     def bake(self, schema):
         extended = schema.find_type(self.name)
         extended.directives.extend(self.directives)
         extended.implemented_fields.update(self.fields)
         extended.interfaces_names.extend(self.interfaces)
+        extended.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/scalar.py
+++ b/tartiflette/types/scalar.py
@@ -164,13 +164,15 @@ class GraphQLScalarType(GraphQLInputType, GraphQLType):
 
 
 class GraphQLScalarTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, directives):
+    def __init__(self, name, directives, definition):
         self.name = name
         self.directives = directives
+        self.definition = definition
 
     def bake(self, schema):
         extended = schema.find_type(self.name)
         extended.directives.extend(self.directives)
+        extended.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tartiflette/types/union.py
+++ b/tartiflette/types/union.py
@@ -52,7 +52,7 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
         """
         super().__init__()
         self.name = name
-        self.types = types
+        self.types = types or []
         self.definition = definition
         self.description = description
         self.possible_types: List["GraphQLType"] = []
@@ -204,16 +204,17 @@ class GraphQLUnionType(GraphQLAbstractType, GraphQLCompositeType):
 
 
 class GraphQLUnionTypeExtension(GraphQLType, GraphQLExtension):
-    def __init__(self, name, directives, types):
+    def __init__(self, name, directives, types, definition):
         self.name = name
         self.directives = directives
         self.types = types or []
+        self.definition = definition
 
     def bake(self, schema):
         extended = schema.find_type(self.name)
-
         extended.directives.extend(self.directives)
         extended.types.extend(self.types)
+        extended.definition |= self.definition
 
     def __eq__(self, other: Any) -> bool:
         """

--- a/tests/unit/types/test_extend_definition.py
+++ b/tests/unit/types/test_extend_definition.py
@@ -1,0 +1,138 @@
+import pytest
+
+from tartiflette import Directive, Resolver, Scalar
+from tartiflette.scalar.builtins.string import ScalarString
+
+
+def bakery(schema_name):
+    Scalar("Baz", schema_name=schema_name)(ScalarString)
+
+    @Directive("dirA", schema_name=schema_name)
+    @Directive("dirB", schema_name=schema_name)
+    @Directive("dirC", schema_name=schema_name)
+    class GenericDirective:
+        pass
+
+    @Resolver("Query.foo", schema_name=schema_name)
+    async def resolver_query_foo(parent, args, ctx, info):
+        return {"id": "1", "name": "Foo"}
+
+
+@pytest.mark.asyncio
+@pytest.mark.with_schema_stack(
+    sdl="""
+    extend scalar Baz @dirB
+
+    extend scalar Baz @dirC
+
+    scalar Baz @dirA
+
+    directive @dirA on | OBJECT | INPUT_OBJECT | ENUM | INTERFACE | SCALAR | UNION
+    directive @dirB on | OBJECT | INPUT_OBJECT | ENUM | INTERFACE | SCALAR | UNION
+    directive @dirC on | OBJECT | INPUT_OBJECT | ENUM | INTERFACE | SCALAR | UNION
+
+    extend interface Identifiable @dirB
+
+    extend interface Identifiable @dirC {
+      id: ID!
+    }
+
+    interface Identifiable @dirA
+
+    interface Named {
+      name: String!
+    }
+
+    extend type Foo implements Identifiable @dirB {
+      id: ID!
+    }
+
+    extend type Foo implements Named @dirC {
+      name: String!
+    }
+
+    type Foo @dirA
+
+    extend input Bar @dirB {
+      id: ID!
+    }
+
+    extend input Bar @dirC {
+      name: String!
+    }
+
+    input Bar @dirA
+
+    extend enum Foobar @dirB {
+      ID
+    }
+
+    extend enum Foobar @dirC {
+      NAME
+    }
+
+    enum Foobar @dirA
+
+    type Foobaz {
+      noop: String!
+    }
+
+    extend union Qux @dirB = Foo
+
+    extend union Qux @dirC = Foobaz
+
+    union Qux @dirA
+
+    type Query {
+      foo: Foo
+    }
+    """,
+    bakery=bakery,
+)
+async def test_extend_definition(schema_stack):
+    assert await schema_stack.execute("{ foo {id, name } }") == {
+        "data": {"foo": {"id": "1", "name": "Foo"}}
+    }
+    scalar_baz = schema_stack.schema.find_type("Baz")
+    interface_identifiable = schema_stack.schema.find_type("Identifiable")
+    type_foo = schema_stack.schema.find_type("Foo")
+    input_bar = schema_stack.schema.find_type("Bar")
+    enum_foobar = schema_stack.schema.find_type("Foobar")
+    union_qux = schema_stack.schema.find_type("Qux")
+
+    for graphql_type in [
+        scalar_baz,
+        interface_identifiable,
+        type_foo,
+        input_bar,
+        enum_foobar,
+        union_qux,
+    ]:
+        assert [
+            directive.name.value
+            for directive in graphql_type.definition.directives
+        ] == ["dirA", "dirB", "dirC"]
+
+    assert [
+        (field.name.value, str(field.type))
+        for field in interface_identifiable.definition.fields
+    ] == [("id", "ID!")]
+
+    assert [
+        (field.name.value, str(field.type))
+        for field in type_foo.definition.fields
+    ] == [("id", "ID!"), ("name", "String!")]
+
+    assert [
+        (field.name.value, str(field.type))
+        for field in input_bar.definition.fields
+    ] == [("id", "ID!"), ("name", "String!")]
+
+    assert [value.name.value for value in enum_foobar.definition.values] == [
+        "ID",
+        "NAME",
+    ]
+
+    assert [
+        union_type.name.value for union_type in union_qux.definition.types
+    ] == ["Foo", "Foobaz"]


### PR DESCRIPTION
The goal of this PR is to extend the `definition` node from GraphQL types at extensions baking process. This will allow to have to complete definition node on directives hooks.

Also, there is a fix on `GraphQLEnumType` and `GraphQLUnionType` where we didn't set some values as list per default which could lead to errors at extensions bake if the type definition didn't mentions enum values/types:
```graphql
enum MyEnum
extend enum MyEnum { # Would raise TypeError (None doesn't have extend method)
  VALUE
}

type Foo {
  id: ID!
}

type Bar {
  id: ID!
}

union MyUnion
extend union MyUnion = Foo | Bar # Would raise TypeError (None doesn't have extend method)
```