### PR TITLE
Expose types to downstream packages

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -19,3 +19,4 @@ recursive-include tartiflette/schema/builtins *.sdl
 include libgraphqlparser/CMakeLists.txt
 include libgraphqlparser/.clang-tidy
 include libgraphqlparser/LICENSE
+include tartiflette/py.typed

--- a/changelogs/next.md
+++ b/changelogs/next.md
@@ -1,1 +1,5 @@
 # [Next]
+
+## Fixed
+
+- Types are now exposed to downstream packages as specified by [PEP-561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information)


### PR DESCRIPTION
I am using Tartiflette for one of my projects and want to run the `mypy` type checker. In order to do this, the `py.typed` file needs to exist, as specified by [PEP-561](https://www.python.org/dev/peps/pep-0561/#packaging-type-information).

I have confirmed that the file exists when creating an `sdist` and a wheel.