### PR TITLE
Simplify GitHub actions workflows

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -7,65 +7,65 @@ name: "CodeQL"
 
 on:
   push:
-    branches: [master]
+    branches: [ master ]
   pull_request:
     # The branches below must be a subset of the branches above
-    branches: [master]
+    branches: [ master ]
   schedule:
     - cron: '0 21 * * 4'
 
 jobs:
   analyze:
     name: Analyze
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
 
     strategy:
       fail-fast: false
       matrix:
         # Override automatic language detection by changing the below list
         # Supported options are ['csharp', 'cpp', 'go', 'java', 'javascript', 'python']
-        language: ['python']
+        language: [ 'python' ]
         # Learn more...
         # https://docs.github.com/en/github/finding-security-vulnerabilities-and-errors-in-your-code/configuring-code-scanning#overriding-automatic-language-detection
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
-      with:
-        # We must fetch at least the immediate parents so that if this is
-        # a pull request then we can checkout the head.
-        fetch-depth: 2
+      - name: Checkout repository
+        uses: actions/checkout@v2
+        with:
+          # We must fetch at least the immediate parents so that if this is
+          # a pull request then we can checkout the head.
+          fetch-depth: 2
 
-    # If this run was triggered by a pull request event, then checkout
-    # the head of the pull request instead of the merge commit.
-    - run: git checkout HEAD^2
-      if: ${{ github.event_name == 'pull_request' }}
+      # If this run was triggered by a pull request event, then checkout
+      # the head of the pull request instead of the merge commit.
+      - run: git checkout HEAD^2
+        if: ${{ github.event_name == 'pull_request' }}
 
-    # Initializes the CodeQL tools for scanning.
-    - name: Initialize CodeQL
-      uses: github/codeql-action/init@v1
-      with:
-        languages: ${{ matrix.language }}
-        # If you wish to specify custom queries, you can do so here or in a config file.
-        # By default, queries listed here will override any specified in a config file. 
-        # Prefix the list here with "+" to use these queries and those in the config file.
-        # queries: ./path/to/local/query, your-org/your-repo/queries@main
+      # Initializes the CodeQL tools for scanning.
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v1
+        with:
+          languages: ${{ matrix.language }}
+          # If you wish to specify custom queries, you can do so here or in a config file.
+          # By default, queries listed here will override any specified in a config file. 
+          # Prefix the list here with "+" to use these queries and those in the config file.
+          # queries: ./path/to/local/query, your-org/your-repo/queries@main
 
-    # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
-    # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
-      uses: github/codeql-action/autobuild@v1
+      # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
+      # If this step fails, then you should remove it and run the build manually (see below)
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@v1
 
-    # ℹ️ Command-line programs to run using the OS shell.
-    # 📚 https://git.io/JvXDl
+      # ℹ️ Command-line programs to run using the OS shell.
+      # 📚 https://git.io/JvXDl
 
-    # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
-    #    and modify them (or add more) to build your code if your project
-    #    uses a compiled language
+      # ✏️ If the Autobuild fails above, remove it and uncomment the following three lines
+      #    and modify them (or add more) to build your code if your project
+      #    uses a compiled language
 
-    #- run: |
-    #   make bootstrap
-    #   make release
+      #- run: |
+      #   make bootstrap
+      #   make release
 
-    - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v1
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v1

--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -1,58 +1,44 @@
 name: Validate PullRequest
-on: [pull_request]
+
+on: pull_request
+
 jobs:
   Style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - name: style
-        uses: ./
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - name: Setup Python 3.9.6
+        uses: actions/setup-python@v2
         with:
-          args: make style
-  TestsUbuntu:
+          python-version: 3.9.6
+      - name: Install Python dependencies
+        run: pip install -e .[test]
+      - run: make style
+  Tests:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-      fail-fast: true
+        os: [ ubuntu-20.04, macos-10.15 ]
+        python-version: [ 3.6, 3.7, 3.8, 3.9 ]
     steps:
-      - uses: actions/checkout@master
-      - name: Set Python Version ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - name: Setup Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
           python-version: ${{ matrix.python-version }}
-      - name: Install Deps
-        run: sudo apt update && sudo apt install cmake && make init && pip install -e .[test]
-      - name: Functional Tests
-        run: make test-functional
-      - name: Unit Tests
-        run: make test-unit
-  TestsMacos:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-      fail-fast: true
-    steps:
-      - uses: actions/checkout@master
-      - name: Set Python Version ${{ matrix.python-version }}
-        uses: actions/setup-python@v1
-        with:
-          python-version: ${{ matrix.python-version }}
-      - name: Install Deps
-        run: brew install cmake
-      - name: Install Python deps
-        run: make init && pip install -e .[test]
+      - name: Install Python dependencies
+        run: pip install -e .[test]
       - name: Functional Tests
         run: make test-functional
       - name: Unit Tests
         run: make test-unit
   SonarCloud:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
       - name: Unshallow
         run: git fetch --unshallow
       - name: SonarCloud Scan
@@ -62,14 +48,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   PublishToPypiDev:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
-      - TestsUbuntu
-      - TestsMacos
+      - Tests
       - Style
       - SonarCloud
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: build and publish to pypi
         uses: ./.github/actions/pypi/
         if: github.ref != 'refs/heads/master'

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -1,33 +1,42 @@
 name: Build'n'Release
+
 on:
   push:
-    branches:
-      - master
+    branches: [ master ]
+
 jobs:
   Style:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - name: style
-        uses: ./
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - name: Setup Python 3.9.6
+        uses: actions/setup-python@v2
         with:
-          args: make style
+          python-version: 3.9.6
+      - name: Install Python dependencies
+        run: pip install -e .[test]
+      - run: make style
   Tests:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
-      - uses: actions/checkout@master
-      - name: functional test
-        uses: ./
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - name: Setup Python 3.9.6
+        uses: actions/setup-python@v2
         with:
-          args: make test-functional
-      - name: unit test
-        uses: ./
-        with:
-          args: make test-unit
+          python-version: 3.9.6
+      - name: Install Python dependencies
+        run: pip install -e .[test]
+      - name: Functional Tests
+        run: make test-functional
+      - name: Unit Tests
+        run: make test-unit
   SonarCloud:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
       - name: Unshallow
         run: git fetch --unshallow
       - name: SonarCloud Scan
@@ -36,13 +45,13 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
   PublishAndRelease:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     needs:
       - Tests
       - Style
       - SonarCloud
     steps:
-      - uses: actions/checkout@master
+      - uses: actions/checkout@v2
       - name: Publish to Pypi
         uses: ./.github/actions/pypi/
         if: github.ref == 'refs/heads/master'

--- a/Makefile
+++ b/Makefile
@@ -8,12 +8,6 @@ PKG_VERSION := $(shell echo | awk -v pkg_version="$(PKG_VERSION)" -v build_numbe
 SET_ALPHA_VERSION = 1
 endif
 
-PATH_TO_MAKEFILE := /github/workspace/Makefile
-ifneq ("$(wildcard $(PATH_TO_MAKEFILE))","")
-IN_GITHUB_ACTION := 1
-else
-IN_GITHUB_ACTION := 0
-endif
 
 .PHONY: init
 init:
@@ -43,9 +37,6 @@ check-format:
 .PHONY: style
 style: check-format check-import
 	pylint tartiflette --rcfile=pylintrc
-ifeq ($(IN_GITHUB_ACTION),1)
-	make clean
-endif
 
 .PHONY: test-integration
 test-integration: clean
@@ -53,25 +44,13 @@ test-integration: clean
 
 .PHONY: test-unit
 test-unit: clean
-ifeq ($(IN_GITHUB_ACTION),1)
-	make install
-endif
 	mkdir -p reports
 	py.test -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
-ifeq ($(IN_GITHUB_ACTION),1)
-	make clean
-endif
 
 .PHONY: test-functional
 test-functional: clean
-ifeq ($(IN_GITHUB_ACTION),1)
-	make install
-endif
 	mkdir -p reports
 	py.test -s tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
-ifeq ($(IN_GITHUB_ACTION),1)
-	make clean
-endif
 
 .PHONY: test
 test: test-integration test-unit test-functional


### PR DESCRIPTION
Simplify GitHub Actions workflows to use native actions.
Merge macOS and Linux tests together in Actions to simplify pull requests workflow.

Another PR will be made later to support building wheels on pull requests (and if it works as expected, on releases later on), so for now this PR leaves a few jobs mostly untouched, as they may completely change later.

Note: Pushing to test pypi seems to be broken, but other PRs are failing too (maybe the token is not valid anymore?).

---
Before submitting your pull-request, make sure the following is done.
* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~
* [x] ~Make sure all of the significant new logic is covered by tests.~
* [x] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.