### PR TITLE
Add wheels support for macOS and Linux

### DIFF
--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -47,7 +47,36 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
-  PublishToPypiDev:
+  PublishWheels:
+    name: Build and publish wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    needs:
+      - Tests
+      - Style
+      - SonarCloud
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macos-10.15 ]
+    steps:
+      - uses: actions/checkout@v2
+      - run: git submodule update --init
+      - run: make set-version
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.0.0a4
+        env:
+          CIBW_ARCHS: native
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: pip install twine==3.4.*
+      - name: Publish wheels to test pypi
+        env:
+          TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        run: twine upload wheelhouse/*
+  PublishSdist:
+    name: Build and publish sdist
     runs-on: ubuntu-20.04
     needs:
       - Tests
@@ -55,9 +84,16 @@ jobs:
       - SonarCloud
     steps:
       - uses: actions/checkout@v2
-      - name: build and publish to pypi
-        uses: ./.github/actions/pypi/
-        if: github.ref != 'refs/heads/master'
+      - run: git submodule update --init
+      - run: make set-version
+      - uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - run: python setup.py sdist
+      - run: pip install twine==3.4.*
+      - name: Publish package to test pypi
         env:
-          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
           TWINE_USERNAME: ${{ secrets.TWINE_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.TWINE_PASSWORD }}
+          TWINE_REPOSITORY_URL: https://test.pypi.org/legacy/
+        run: twine upload dist/*

--- a/Makefile
+++ b/Makefile
@@ -64,7 +64,7 @@ clean:
 .PHONY: set-version
 set-version:
 ifneq ($(SET_ALPHA_VERSION), 0)
-	bash -c "sed -i \"s@_VERSION[ ]*=[ ]*[\\\"\'][0-9]\+\\.[0-9]\+\\.[0-9]\+\(rc[0-9]\+\)\?[\\\"\'].*@_VERSION = \\\"$(PKG_VERSION)\\\"@\" setup.py"
+	bash -c "sed -i -e 's!^\(\s*_VERSION = \).*!\1\"$(PKG_VERSION)\"!' setup.py"
 endif
 
 .PHONY: run-docs

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from setuptools import find_packages, setup
+from setuptools import Extension, find_packages, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 
@@ -31,21 +31,24 @@ def _build_libgraphqlparser():
 
     os.rename(
         artifact_path,
-        "tartiflette/language/parsers/libgraphqlparser/cffi/%s"
-        % os.path.basename(artifact_path),
+        f"tartiflette/language/parsers/libgraphqlparser/cffi/{os.path.basename(artifact_path)}",
     )
 
 
 class BuildExtCmd(build_ext):
     def run(self):
         _build_libgraphqlparser()
-        build_ext.run(self)
 
 
 class BuildPyCmd(build_py):
     def run(self):
         _build_libgraphqlparser()
-        build_py.run(self)
+        super().run()
+
+
+class LibGraphQLParserExtension(Extension):
+    def __init__(self):
+        super().__init__("libgraphqlparser", sources=[])
 
 
 _TEST_REQUIRE = [
@@ -92,5 +95,6 @@ setup(
     tests_require=_TEST_REQUIRE,
     extras_require={"test": _TEST_REQUIRE, "benchmark": _BENCHMARK_REQUIRE},
     cmdclass={"build_ext": BuildExtCmd, "build_py": BuildPyCmd},
+    ext_modules=[LibGraphQLParserExtension()],
     include_package_data=True,
 )


### PR DESCRIPTION
Build wheels for macOS and Linux using `cibuildwheel` on pull requests.

This uses a "fake" extension to ensure that we build platform dependant wheels instead of pure Python ones (as libgraphqlparser build different files).
Another potential way to do this would be to provide a distclass with an `has_ext_modules` method returning `True`, but `auditwheel` library used by `cibuildwheel` wasn't so happy with it.

Known issues:
- As we have 3 different workers building packages (sdist, macOS wheels and Linux wheels), the timestamp used to define the dev version is not the same. I didn't find a proper way to handle this, apart from doing a modulo to have a minute/hour granularity on the timestamp, but if you think it's important to have this, we can discuss about a solution.

Note: For now, we only do that for pull requests, not for releases, as this would give time to check that everything looks fine.

---
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~
* [x] ~Make sure all of the significant new logic is covered by tests.~
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*