### PR TITLE
Allow for specifing SDL file encoding (or rely on locale.getprefferedencoding(False))

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -56,7 +56,7 @@ _TEST_REQUIRE = [
     "pytest-cov==2.12.1",
     "pytest-asyncio==0.15.1",
     "pytest-xdist==2.3.0",
-    "pylint==2.9.5",
+    "pylint==2.10.2",
     "black==21.8b0",
     "isort==5.9.3",
 ]

--- a/tartiflette/schema/builtins/introspection.py
+++ b/tartiflette/schema/builtins/introspection.py
@@ -86,6 +86,7 @@ def bake(schema_name: str, config: Optional[Dict[str, Any]] = None) -> str:
     )
     Resolver("__Type.fields", schema_name=schema_name)(resolve_type_fields)
     with open(
-        os.path.join(os.path.dirname(__file__), "introspection.sdl")
+        os.path.join(os.path.dirname(__file__), "introspection.sdl"),
+        encoding="UTF-8",
     ) as file:
         return file.read()

--- a/tartiflette/schema/registry.py
+++ b/tartiflette/schema/registry.py
@@ -161,6 +161,7 @@ class SchemaRegistry:
     def register_sdl(
         schema_name: str,
         sdl: Union[str, List[str], "GraphQLSchema"],
+        sdl_file_encoding: str,
         modules_sdl: Optional[str] = None,
     ) -> None:
         """
@@ -168,9 +169,11 @@ class SchemaRegistry:
         :param schema_name: name of the schema
         :param sdl: path(s) to the SDL or raw string representing the SDL
         :param modules_sdl: extra SDL from the imported modules
+        :param sdl_file_encoding: sdl file encoding
         :type schema_name: str
         :type sdl: Union[str, List[str], GraphQLSchema]
         :type modules_sdl: Optional[str]
+        :type sdl_file_encoding: str
         """
         SchemaRegistry._schemas.setdefault(schema_name, {})
 
@@ -190,7 +193,9 @@ class SchemaRegistry:
 
         # Convert SDL files into big schema and parse it
         for filepath in sdl_files_list:
-            with open(filepath, mode="r") as sdl_file:
+            with open(
+                filepath, mode="r", encoding=sdl_file_encoding
+            ) as sdl_file:
                 full_sdl += "\n" + sdl_file.read()
 
         if modules_sdl:

--- a/tests/unit/test_resolver_decorator.py
+++ b/tests/unit/test_resolver_decorator.py
@@ -69,7 +69,7 @@ async def test_resolver_decorator(clean_registry):
 
     _, schema_sdl = await _import_builtins([], schema_sdl, "default")
 
-    clean_registry.register_sdl("default", schema_sdl)
+    clean_registry.register_sdl("default", schema_sdl, "UTF-8")
 
     mock_one = Mock()
     mock_two = Mock()

--- a/tests/unit/test_schema_unit.py
+++ b/tests/unit/test_schema_unit.py
@@ -58,7 +58,7 @@ async def test_schema_object_get_field_name(clean_registry):
     """
 
     _, schema_sdl = await _import_builtins([], schema_sdl, "default")
-    clean_registry.register_sdl("A", schema_sdl)
+    clean_registry.register_sdl("A", schema_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("A")
 
     with pytest.raises(ImproperlyConfigured):
@@ -162,7 +162,7 @@ async def test_schema_validate_named_types(
 ):
 
     _, full_sdl = await _import_builtins([], full_sdl, "A")
-    clean_registry.register_sdl("A", full_sdl)
+    clean_registry.register_sdl("A", full_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("A")
 
     if expected_error:
@@ -324,7 +324,7 @@ async def test_schema_validate_object_follow_interfaces(
     full_sdl, expected_error, clean_registry
 ):
     _, full_sdl = await _import_builtins([], full_sdl, "A")
-    clean_registry.register_sdl("A", full_sdl)
+    clean_registry.register_sdl("A", full_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("A")
 
     try:
@@ -447,7 +447,7 @@ async def test_schema_validate_root_types_exist(
     full_sdl, expected_error, clean_registry
 ):
     _, full_sdl = await _import_builtins([], full_sdl, "a")
-    clean_registry.register_sdl("a", full_sdl)
+    clean_registry.register_sdl("a", full_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("a")
 
     if expected_error:
@@ -484,7 +484,7 @@ async def test_schema_validate_non_empty_object(
     full_sdl, expected_error, clean_registry
 ):
     _, full_sdl = await _import_builtins([], full_sdl, "a")
-    clean_registry.register_sdl("a", full_sdl)
+    clean_registry.register_sdl("a", full_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("a")
 
     if expected_error:
@@ -534,7 +534,7 @@ async def test_schema_validate_union_is_acceptable(
     full_sdl, expected_error, clean_registry
 ):
     _, full_sdl = await _import_builtins([], full_sdl, "a")
-    clean_registry.register_sdl("a", full_sdl)
+    clean_registry.register_sdl("a", full_sdl, "UTF-8")
     generated_schema = SchemaBakery._preheat("a")
 
     if expected_error:
@@ -554,7 +554,7 @@ async def test_schema_bake_schema(clean_registry):
         }""",
         "a",
     )
-    clean_registry.register_sdl("a", full_sdl)
+    clean_registry.register_sdl("a", full_sdl, "UTF-8")
     assert await SchemaBakery.bake("a") is not None
 
 
@@ -576,7 +576,7 @@ async def test_schema_has_type(clean_registry, type_name, expected):
         """,
         "a",
     )
-    clean_registry.register_sdl("a", full_sdl)
+    clean_registry.register_sdl("a", full_sdl, "UTF-8")
     schema = await SchemaBakery.bake("a")
     assert schema.has_type(type_name) is expected
 


### PR DESCRIPTION
On future version of python, open will use UTF-8 as a default and not the system prefered one. So I'd like to offer the capability to user to specify at Init/cook time the encoding of their SDL file (we'll use default system one per default if value is None).