### PR TITLE
Remove unused `pytz` dependency

### DIFF
--- a/changelogs/next.md
+++ b/changelogs/next.md
@@ -3,3 +3,4 @@
 ## Added
 
 - [PR-525](https://github.com/tartiflette/tartiflette/pull/525) - Python 3.10 is now officially supported
+- [PR-529](https://github.com/tartiflette/tartiflette/pull/529) - Remove unused `pytz` dependency

--- a/setup.py
+++ b/setup.py
@@ -96,7 +96,7 @@ setup(
     ],
     keywords="api graphql protocol api rest relay tartiflette dailymotion",
     packages=_PACKAGES,
-    install_requires=["cffi>=1.0.0,<2.0.0", "lark-parser==0.12.0", "pytz"],
+    install_requires=["cffi>=1.0.0,<2.0.0", "lark-parser==0.12.0"],
     tests_require=_TEST_REQUIRE,
     extras_require={"test": _TEST_REQUIRE, "benchmark": _BENCHMARK_REQUIRE},
     cmdclass={"build_ext": BuildExtCmd, "build_py": BuildPyCmd},


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] Update changelogs/next.md with your change (include reference to the issue & this PR).
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*

It looks like `tartiflette` unnecessarily depends on `pytz`, which is not used in the codebase.
For reference, it was added [here](https://github.com/tartiflette/tartiflette/pull/88/files#diff-60f61ab7a8d1910d86d9fda2261620314edcae5894d5aaa236b821c7256badd7R89) at the time.