### PR TITLE
Fix some deprecation warnings

### DIFF
--- a/tartiflette/language/parsers/lark/transformers/token_transformer.py
+++ b/tartiflette/language/parsers/lark/transformers/token_transformer.py
@@ -126,7 +126,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "INT_VALUE",
                 int(token.value),
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -148,7 +148,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "FLOAT_VALUE",
                 float("".join([child.value for child in tree.children])),
-                first_token.pos_in_stream,
+                first_token.start_pos,
                 first_token.line,
                 first_token.column,
             ),
@@ -178,7 +178,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "STRING_VALUE",
                 value,
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -200,7 +200,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "BOOLEAN_VALUE",
                 token.type == "TRUE",
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -222,7 +222,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "NULL_VALUE",
                 None,
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -244,7 +244,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "ENUM",
                 token.value,
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -266,7 +266,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "NAME",
                 token.value,
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),
@@ -288,7 +288,7 @@ class TokenTransformer(Transformer_InPlace):
             Token(
                 "DESCRIPTION",
                 token.value,
-                token.pos_in_stream,
+                token.start_pos,
                 token.line,
                 token.column,
             ),

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -37,7 +37,7 @@ for schema_name, sdl in _SCHEMAS.items():
     )
 
 
-@pytest.yield_fixture(scope="module")
+@pytest.fixture(scope="module")
 def event_loop():
     loop = asyncio.new_event_loop()
     yield loop

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -3,7 +3,7 @@ import pytest
 from tartiflette.schema.registry import SchemaRegistry
 
 
-@pytest.yield_fixture
+@pytest.fixture
 def clean_registry():
     SchemaRegistry.clean()
     yield SchemaRegistry

--- a/tests/unit/language/parsers/lark/test_strings_parser.py
+++ b/tests/unit/language/parsers/lark/test_strings_parser.py
@@ -1702,7 +1702,7 @@ def test_lark_parsed_string_value_from_file(sdl_filename, expected):
         (
             """
             directive @deprecated(
-                reason: String = "No \\\ supported"
+                reason: String = "No \\\\ supported"
             ) on FIELD_DEFINITION
             """,
             DocumentNode(
@@ -2206,7 +2206,7 @@ def test_lark_parsed_string_value_from_file(sdl_filename, expected):
         (
             """
             directive @deprecated(
-                reason: String = "No \\u05fd \\uabcd \\u0123 \\t \\r \\n \\f \\/ \\" \\\ \\b supported"
+                reason: String = "No \\u05fd \\uabcd \\u0123 \\t \\r \\n \\f \\/ \\" \\\\ \\b supported"
             ) on FIELD_DEFINITION
             """,
             DocumentNode(


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [ ] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~ Not applicable
* [x] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*

Replace some deprecated usages:
- `lark-parser`: `Token.pos_in_stream` -> `Token.start_pos` (deprecated in 0.12.0, [reference](https://github.com/lark-parser/lark/commit/2409065529f447ee12c77d015e02eefc6ceb8f5d#diff-590aa22e2712d270f8ec66a63ef40f0bc75bb564f20d59d854b207dcb704fee3R151-R154))
- `pytest`: `yield_fixture` -> `fixture` (deprecated in 6.2.0, [reference](https://docs.pytest.org/en/6.2.x/changelog.html#pytest-6-2-0-2020-12-12))