### PR TITLE
Use xdist for functional tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,8 +1,0 @@
-[run]
-data_file = reports/.coverage
-omit =
-    tests/*
-    __init__.py
-
-[report]
-show_missing = True

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ test-unit: clean
 .PHONY: test-functional
 test-functional: clean
 	mkdir -p reports
-	pytest -s tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
+	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
 
 .PHONY: test
 test: test-unit test-functional

--- a/Makefile
+++ b/Makefile
@@ -28,11 +28,11 @@ style: check-format check-import
 
 .PHONY: test-unit
 test-unit: clean
-	pytest -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
+	pytest -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
 
 .PHONY: test-functional
 test-functional: clean
-	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
+	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
 
 .PHONY: test
 test: test-unit test-functional

--- a/Makefile
+++ b/Makefile
@@ -28,12 +28,10 @@ style: check-format check-import
 
 .PHONY: test-unit
 test-unit: clean
-	mkdir -p reports
 	pytest -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
 
 .PHONY: test-functional
 test-functional: clean
-	mkdir -p reports
 	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
 
 .PHONY: test

--- a/Makefile
+++ b/Makefile
@@ -29,12 +29,12 @@ style: check-format check-import
 .PHONY: test-unit
 test-unit: clean
 	mkdir -p reports
-	pytest -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
+	pytest -s tests/unit --junitxml=reports/report_unit_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
 
 .PHONY: test-functional
 test-functional: clean
 	mkdir -p reports
-	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_unit.xml $(EXTRA_ARGS)
+	pytest -n auto tests/functional --junitxml=reports/report_func_tests.xml --cov . --cov-config .coveragerc --cov-report term-missing --cov-report xml:reports/coverage_func.xml $(EXTRA_ARGS)
 
 .PHONY: test
 test: test-unit test-functional

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,3 +11,13 @@ known_first_party = [
 ]
 combine_as_imports = true
 lines_between_types = 1
+
+[tool.coverage.run]
+data_file = "reports/.coverage"
+omit = [
+    "tests/*",
+    "__init__.py"
+]
+
+[tool.coverage.report]
+show_missing = true


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [ ] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~ Not applicable
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*

`tartiflette` currently depends on `pytest-xdist` for test dependencies, but doesn't make use of it.
Passing `-n auto` to `pytest` for functional tests speeds up test durations both locally and on the CI.
As functional tests are isolated, it shouldn't cause any issue.

For unit tests, they are already rather fast, so it is not worth IMO to use multiple processes.