### PR TITLE
Use `setup.cfg` to define most package metadata

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ clean:
 
 .PHONY: set-dev-version
 set-dev-version:
-	bash -c "sed -i -e 's!^\(\s*_VERSION = \).*!\1\"$(shell $(MAKE) get-version).dev$(shell date +\"%s\")\"!' setup.py"
+	@bash -c "sed -i -e 's!^\(\s*version = \).*!\1$(shell $(MAKE) get-version).dev$(shell date +\"%s\")!' setup.cfg"
 
 .PHONY: run-docs
 run-docs:
@@ -54,4 +54,4 @@ run-docs:
 
 .PHONY: get-version
 get-version:
-	@echo $(shell cat setup.py | grep "_VERSION =" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?')
+	@echo $(shell cat setup.cfg | grep "version =" | egrep -o '[0-9]+\.[0-9]+\.[0-9]+(rc[0-9]+)?')

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,10 @@
+[build-system]
+requires = [
+    "setuptools>=39.2.0",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"
+
 [tool.black]
 line_length = 79
 target-version = ["py36"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,51 @@
+[metadata]
+name = tartiflette
+version = 1.4.0
+description = GraphQL Engine for Python
+long_description = file: README.md
+long_description_content_type = text/markdown
+url = https://github.com/tartiflette/tartiflette
+author = Dailymotion Core API Team
+author_email = team@tartiflette.io
+license = MIT
+license_files = LICENSE
+classifiers =
+    Intended Audience :: Developers
+    Topic :: Software Development :: Libraries
+    Programming Language :: Python :: 3.6
+    Programming Language :: Python :: 3.7
+    Programming Language :: Python :: 3.8
+    Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: Implementation :: CPython
+    Programming Language :: Python :: Implementation :: PyPy
+keywords =
+    api
+    graphql
+    protocol
+    rest
+    relay
+    tartiflette
+    dailymotion
+
+[options]
+python_requires = >=3.6
+install_requires =
+    cffi>=1.0.0,<2.0.0
+    lark-parser==0.12.0
+packages = find:
+include_package_data = True
+
+[options.extras_require]
+test =
+    pytest==6.2.5
+    pytest-cov==2.12.1
+    pytest-asyncio==0.15.1
+    pytest-xdist==2.3.0
+    pylint==2.10.2
+    black==21.8b0
+    isort==5.9.3
+benchmark = pytest-benchmark==3.4.1
+
+[options.packages.find]
+exclude = tests*

--- a/setup.cfg
+++ b/setup.cfg
@@ -4,11 +4,16 @@ version = 1.4.0
 description = GraphQL Engine for Python
 long_description = file: README.md
 long_description_content_type = text/markdown
-url = https://github.com/tartiflette/tartiflette
+url = https://tartiflette.io
 author = Dailymotion Core API Team
 author_email = team@tartiflette.io
 license = MIT
 license_files = LICENSE
+project_urls =
+    Documentation = https://tartiflette.io
+    Source code = https://github.com/tartiflette/tartiflette
+    Changelog = https://github.com/tartiflette/tartiflette/blob/master/CHANGELOG.md
+    Issue tracker = https://github.com/tartiflette/tartiflette/issues
 classifiers =
     Intended Audience :: Developers
     Topic :: Software Development :: Libraries

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ import os
 import subprocess
 import sys
 
-from setuptools import Extension, find_packages, setup
+from setuptools import Extension, setup
 from setuptools.command.build_ext import build_ext
 from setuptools.command.build_py import build_py
 
@@ -51,55 +51,7 @@ class LibGraphQLParserExtension(Extension):
         super().__init__("libgraphqlparser", sources=[])
 
 
-_TEST_REQUIRE = [
-    "pytest==6.2.5",
-    "pytest-cov==2.12.1",
-    "pytest-asyncio==0.15.1",
-    "pytest-xdist==2.3.0",
-    "pylint==2.10.2",
-    "black==21.8b0",
-    "isort==5.9.3",
-]
-
-_BENCHMARK_REQUIRE = ["pytest-benchmark==3.4.1"]
-
-_VERSION = "1.4.0"
-
-_PACKAGES = find_packages(exclude=["tests*"])
-
-
-def _read_file(filename):
-    with open(filename) as afile:
-        return afile.read()
-
-
 setup(
-    name="tartiflette",
-    version=_VERSION,
-    description="GraphQL Engine for Python",
-    long_description=_read_file("README.md"),
-    long_description_content_type="text/markdown",
-    url="https://github.com/tartiflette/tartiflette",
-    author="Dailymotion Core API Team",
-    author_email="team@tartiflette.io",
-    license="MIT",
-    classifiers=[
-        "Intended Audience :: Developers",
-        "Topic :: Software Development :: Libraries",
-        "Programming Language :: Python :: 3.6",
-        "Programming Language :: Python :: 3.7",
-        "Programming Language :: Python :: 3.8",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: Implementation :: CPython",
-        "Programming Language :: Python :: Implementation :: PyPy",
-    ],
-    keywords="api graphql protocol api rest relay tartiflette dailymotion",
-    packages=_PACKAGES,
-    install_requires=["cffi>=1.0.0,<2.0.0", "lark-parser==0.12.0"],
-    tests_require=_TEST_REQUIRE,
-    extras_require={"test": _TEST_REQUIRE, "benchmark": _BENCHMARK_REQUIRE},
     cmdclass={"build_ext": BuildExtCmd, "build_py": BuildPyCmd},
     ext_modules=[LibGraphQLParserExtension()],
-    include_package_data=True,
 )


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [ ] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~ Not applicable
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*

Define package metadata and requirements in `setup.cfg`, with regards to [setuptools documentation](https://setuptools.pypa.io/en/latest/userguide/declarative_config.html), allowing to have declarative configuration which should be easier to maintain.

Tested in https://github.com/mkniewallner/tartiflette/pull/5, with the source published [here](https://test.pypi.org/project/tartiflette-wheels/1.4.0.dev1632517466/).
Taking the occasion to add `python_requires` and `project_urls` to the metadata, in order to have link to issues, source code, changelog and documentation directly from PyPI.
`tests_require` is removed because it's been deprecated in favor of `extras_require` (https://github.com/pypa/setuptools/issues/1684)

Note that dependabot will continue to work as expected, as support for `setup.cfg` has been added [a few months ago](https://github.com/dependabot/dependabot-core/blob/main/CHANGELOG.md#v01430-21-april-2021).