### PR TITLE
Use Python 3.10 on CI

### DIFF
--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -62,7 +62,7 @@ jobs:
       - run: git submodule update --init
       - run: make set-dev-version
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_ARCHS: native
       - uses: actions/setup-python@v2

--- a/.github/workflows/on_pull_requests.yml
+++ b/.github/workflows/on_pull_requests.yml
@@ -8,10 +8,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init
-      - name: Setup Python 3.9.6
+      - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9.6"
+          python-version: "3.10"
       - name: Install Python dependencies
         run: pip install -e .[test]
       - run: make style
@@ -20,7 +20,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-20.04, macos-10.15 ]
-        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10.0-rc.2" ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -18,14 +18,18 @@ jobs:
         run: pip install -e .[test]
       - run: make style
   Tests:
-    runs-on: ubuntu-20.04
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ ubuntu-20.04, macos-10.15 ]
+        python-version: [ "3.6", "3.7", "3.8", "3.9", "3.10" ]
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init
-      - name: Setup Python 3.10
+      - name: Setup Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
         with:
-          python-version: "3.10"
+          python-version: ${{ matrix.python-version }}
       - name: Install Python dependencies
         run: pip install -e .[test]
       - name: Functional Tests

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -37,7 +37,7 @@ jobs:
       - name: Unit Tests
         run: make test-unit
   SonarCloud:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -93,7 +93,7 @@ jobs:
       - uses: actions/checkout@v2
       - run: git submodule update --init
       - name: Build wheels
-        uses: pypa/cibuildwheel@v2.1.1
+        uses: pypa/cibuildwheel@v2.1.2
         env:
           CIBW_ARCHS: native
       - uses: actions/setup-python@v2

--- a/.github/workflows/push_on_master.yml
+++ b/.github/workflows/push_on_master.yml
@@ -10,10 +10,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init
-      - name: Setup Python 3.9.6
+      - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9.6"
+          python-version: "3.10"
       - name: Install Python dependencies
         run: pip install -e .[test]
       - run: make style
@@ -22,10 +22,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - run: git submodule update --init
-      - name: Setup Python 3.9.6
+      - name: Setup Python 3.10
         uses: actions/setup-python@v2
         with:
-          python-version: "3.9.6"
+          python-version: "3.10"
       - name: Install Python dependencies
         run: pip install -e .[test]
       - name: Functional Tests


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [ ] ~Update changelogs/next.md with your change (include reference to the issue & this PR).~ Not applicable
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

*[Learn more about contributing](https://github.com/tartiflette/tartiflette/blob/master/docs/CONTRIBUTING.md)*

- Use Python 3.10 to run `style`, now that it's been [officially released](https://pythoninsider.blogspot.com/2021/10/python-3100-is-available.html).
- Run tests against multiple Python version on `master` branch
- Bump `cibuildwheel` to `2.1.2` to benefit from [building wheels against Python 3.10.0rc2](https://github.com/pypa/cibuildwheel/releases/tag/v2.1.2)

_Note: for now, jobs for uploading sdist/wheels still run against Python 3.9 because `twine` [doesn't officially support Python 3.10](https://github.com/pypa/twine/blob/6e6cf82ea110c07808afb4059eb26ef03945f450/setup.cfg#L14-L30) yet._