### PR TITLE
Depend on `lark>=1.0.0`

### DIFF
--- a/changelogs/next.md
+++ b/changelogs/next.md
@@ -4,4 +4,6 @@
 
 ## Changed
 
+- [PR-554](https://github.com/tartiflette/tartiflette/pull/554) - Require `lark>=1.0.0` in place of `lark-parser==0.12.0`
+
 ## Fixed

--- a/setup.cfg
+++ b/setup.cfg
@@ -37,7 +37,7 @@ keywords =
 python_requires = >=3.6
 install_requires =
     cffi>=1.0.0,<2.0.0
-    lark-parser==0.12.0
+    lark>=1.0.0,<2.0.0
 packages = find:
 include_package_data = True
 


### PR DESCRIPTION
Before submitting your pull-request, make sure the following is done.

* [x] Fork [the repository](https://github.com/tartiflette/tartiflette) and create your branch from `master` so that it can be merged easily.
* [x] Update changelogs/next.md with your change (include reference to the issue & this PR).
* [ ] ~Make sure all of the significant new logic is covered by tests.~ Not applicable
* [ ] Make sure all quality checks are green _[(Gazr specification)](https://gazr.io)_.

## Description
`lark-parser` [reached version 1.0.0](https://github.com/lark-parser/lark/releases/tag/1.0.0) on November 2021.
None of the breaking changes appears to impact the codebase, but the package is now published as [`lark`](https://pypi.org/project/lark/#history) on PyPi instead of [`lark-parser`](https://pypi.org/project/lark-parser/#history).

Instead of pinning a specific version like we currently do, this PR also relaxes the requirement by allowing any `1.x` minor version.
This would mostly be beneficial for projects having multiple dependencies that depend on `lark`.

We might also consider not setting any upper bound constraint at all, like a lot of projects recently started to do (see [this article](https://iscinumpy.dev/post/bound-version-constraints/) to understand a bit why).